### PR TITLE
Add job status polling

### DIFF
--- a/executor/batchclient/batch.go
+++ b/executor/batchclient/batch.go
@@ -37,9 +37,11 @@ func NewBatchExecutor(client batchiface.BatchAPI, queue string) BatchExecutor {
 func (be BatchExecutor) Status(tasks []*resources.Task) []error {
 	status := map[string]*resources.Task{}
 	jobs := []*string{}
+	taskIds := []string{}
 
 	for _, task := range tasks {
 		jobs = append(jobs, aws.String(task.ID))
+		taskIds = append(taskIds, task.ID)
 		status[task.ID] = task
 	}
 
@@ -48,6 +50,10 @@ func (be BatchExecutor) Status(tasks []*resources.Task) []error {
 	})
 	if err != nil {
 		return []error{err}
+	}
+	// TODO: aws seems to silently fail on no jobs found. need to investigate
+	if len(results.Jobs) == 0 {
+		return []error{fmt.Errorf("No task(s) found: %v.", taskIds)}
 	}
 
 	var taskErrors []error

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -114,8 +114,9 @@ func (jm BatchJobManager) CreateJob(def resources.WorkflowDefinition, input []st
 
 func (jm BatchJobManager) pollUpdateStatus(job *resources.Job) {
 	for {
-		switch job.Status {
-		case resources.Cancelled, resources.Failed, resources.Succeeded:
+		if job.Status == resources.Cancelled ||
+			job.Status == resources.Failed ||
+			job.Status == resources.Succeeded {
 			// no need to poll anymore
 			log.InfoD("job-polling-stop", logger.M{
 				"id":       job.ID,

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -3,9 +3,13 @@ package executor
 import (
 	"fmt"
 
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
 )
+
+var log = logger.New("workflow-manager")
 
 // JobManager in the interface for creating, stopping and checking status for Jobs (workflow runs)
 type JobManager interface {
@@ -30,13 +34,31 @@ func NewBatchJobManager(executor Executor, store store.Store) BatchJobManager {
 
 // UpdateJobStatus ensures that the status of the tasks is in-sync with AWS Batch and sets Job status
 func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
+	// copy current status
+	taskStatus := map[string]resources.TaskStatus{}
+	for _, task := range job.Tasks {
+		taskStatus[task.ID] = task.Status
+	}
+
+	// fetch new status from batch
 	errs := jm.executor.Status(job.Tasks)
 	if len(errs) > 0 {
 		return fmt.Errorf("Failed to update status for %d tasks. errors: %s", len(errs), errs)
 	}
+
 	if job.Status == resources.Cancelled {
 		// if a job is cancelled, just return the updated task status
 		// JobStatus should remain cancelled
+		return nil
+	}
+	// if no task status has changed skip store updates
+	noChanges := true
+	for _, task := range job.Tasks {
+		if task.Status != taskStatus[task.ID] {
+			noChanges = false
+		}
+	}
+	if noChanges {
 		return nil
 	}
 
@@ -82,7 +104,34 @@ func (jm BatchJobManager) CreateJob(def resources.WorkflowDefinition, input []st
 	// 1. reconcile somehow with the scheduled tasks
 	// 2. kill the running tasks so that we don't have orphan tasks in AWS Batch
 	err = jm.store.SaveJob(*job)
+
+	// TODO: remove this polling and replace by ECS task event processing
+	go jm.pollUpdateStatus(job)
+
 	return job, err
+}
+
+func (jm BatchJobManager) pollUpdateStatus(job *resources.Job) {
+	for {
+		switch job.Status {
+		case resources.Cancelled, resources.Failed, resources.Succeeded:
+			// no need to poll anymore
+			log.InfoD("job-polling-stop", logger.M{
+				"id":       job.ID,
+				"status":   job.Status,
+				"workflow": job.Workflow.Name(),
+			})
+			break
+		}
+		if err := jm.UpdateJobStatus(job); err != nil {
+			log.ErrorD("job-polling-error", logger.M{
+				"id":       job.ID,
+				"status":   job.Status,
+				"workflow": job.Workflow.Name(),
+				"error":    err.Error(),
+			})
+		}
+	}
 }
 
 func (jm BatchJobManager) CancelJob(job *resources.Job, reason string) error {

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 
@@ -131,6 +132,7 @@ func (jm BatchJobManager) pollUpdateStatus(job *resources.Job) {
 				"error":    err.Error(),
 			})
 		}
+		time.Sleep(time.Minute)
 	}
 }
 


### PR DESCRIPTION
add polling for task updates
* start a goroutine when creating a new job
* stop polling if the job status becomes Cancelled, Failed, Succeeded
* restarts will cause polling to stop; okay to deal with this right now
we need to eventually ECS task event listener via SNS/SQS
* don't update the DB if no task.Status has changed