### PR TITLE
executor: log job create, cancel, and status change

### DIFF
--- a/executor/batchclient/batch_test.go
+++ b/executor/batchclient/batch_test.go
@@ -47,7 +47,7 @@ func TestJobToTaskDetail(t *testing.T) {
 	assert.NotNil(t, taskDetail)
 
 	assert.Equal(t, taskDetail.Status, resources.TaskStatusSucceeded)
-	assert.Equal(t, taskDetail.CreatedAt.Format(time.RFC3339Nano), "2017-03-28T00:45:46.376Z")
-	assert.Equal(t, taskDetail.StartedAt.Format(time.RFC3339Nano), "2017-03-28T00:46:48.178Z")
+	assert.Equal(t, taskDetail.CreatedAt.UTC().Format(time.RFC3339Nano), "2017-03-28T00:45:46.376Z")
+	assert.Equal(t, taskDetail.StartedAt.UTC().Format(time.RFC3339Nano), "2017-03-28T00:46:48.178Z")
 	assert.Equal(t, taskDetail.StoppedAt, time.Time{})
 }

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -94,7 +94,7 @@ func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
 	// If the status was updated, log it and save to datastore
 	if previousStatus != job.Status {
 		log.InfoD("job-status-change", logger.M{
-			"job-id": job.ID,
+			"id":     job.ID,
 			"before": previousStatus,
 			"after":  job.Status,
 		})

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -98,9 +98,8 @@ func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
 			"before": previousStatus,
 			"after":  job.Status,
 		})
-		return jm.store.UpdateJob(*job)
 	}
-	return nil
+	return jm.store.UpdateJob(*job)
 }
 
 // CreateJob can be used to create a new job for a workflow

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -94,9 +94,11 @@ func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
 	// If the status was updated, log it and save to datastore
 	if previousStatus != job.Status {
 		log.InfoD("job-status-change", logger.M{
-			"id":     job.ID,
-			"before": previousStatus,
-			"after":  job.Status,
+			"id":               job.ID,
+			"workflow":         job.Workflow.Name(),
+			"workflow-version": job.Workflow.Version(),
+			"before":           previousStatus,
+			"after":            job.Status,
 		})
 	}
 	return jm.store.UpdateJob(*job)
@@ -105,7 +107,11 @@ func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
 // CreateJob can be used to create a new job for a workflow
 func (jm BatchJobManager) CreateJob(def resources.WorkflowDefinition, input []string) (*resources.Job, error) {
 	job := resources.NewJob(def, input)
-	log.InfoD("job-created", logger.M{"id": job.ID})
+	log.InfoD("job-created", logger.M{
+		"id":               job.ID,
+		"workflow":         job.Workflow.Name(),
+		"workflow-version": job.Workflow.Version(),
+	})
 
 	err := jm.scheduleTasks(job, input)
 	if err != nil {
@@ -151,8 +157,10 @@ func (jm BatchJobManager) pollUpdateStatus(job *resources.Job) {
 func (jm BatchJobManager) CancelJob(job *resources.Job, reason string) error {
 	// don't cancel already succeeded tasks
 	log.InfoD("job-cancelled", logger.M{
-		"id":     job.ID,
-		"reason": reason,
+		"id":               job.ID,
+		"workflow":         job.Workflow.Name(),
+		"workflow-version": job.Workflow.Version(),
+		"reason":           reason,
 	})
 
 	tasks := []*resources.Task{}

--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -35,6 +35,8 @@ func NewBatchJobManager(executor Executor, store store.Store) BatchJobManager {
 
 // UpdateJobStatus ensures that the status of the tasks is in-sync with AWS Batch and sets Job status
 func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
+	previousStatus := job.Status
+
 	// copy current status
 	taskStatus := map[string]resources.TaskStatus{}
 	for _, task := range job.Tasks {
@@ -89,12 +91,22 @@ func (jm BatchJobManager) UpdateJobStatus(job *resources.Job) error {
 		job.Status = resources.Succeeded
 	}
 
-	return jm.store.UpdateJob(*job)
+	// If the status was updated, log it and save to datastore
+	if previousStatus != job.Status {
+		log.InfoD("job-status-change", logger.M{
+			"job-id": job.ID,
+			"before": previousStatus,
+			"after":  job.Status,
+		})
+		return jm.store.UpdateJob(*job)
+	}
+	return nil
 }
 
 // CreateJob can be used to create a new job for a workflow
 func (jm BatchJobManager) CreateJob(def resources.WorkflowDefinition, input []string) (*resources.Job, error) {
 	job := resources.NewJob(def, input)
+	log.InfoD("job-created", logger.M{"id": job.ID})
 
 	err := jm.scheduleTasks(job, input)
 	if err != nil {
@@ -139,6 +151,11 @@ func (jm BatchJobManager) pollUpdateStatus(job *resources.Job) {
 
 func (jm BatchJobManager) CancelJob(job *resources.Job, reason string) error {
 	// don't cancel already succeeded tasks
+	log.InfoD("job-cancelled", logger.M{
+		"id":     job.ID,
+		"reason": reason,
+	})
+
 	tasks := []*resources.Task{}
 	for _, task := range job.Tasks {
 		switch task.Status {


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2299

Also modifies the job status change logic, so that we only save the job
to the store if its status has changed.

- [ ] Update swagger.yml version
- [ ] Run "make generate"
- [ ] After merging, add a github tag to your merge commit
