### PR TITLE
Dynamic jobdefinition lookup

### DIFF
--- a/executor/job_manager.go
+++ b/executor/job_manager.go
@@ -14,7 +14,7 @@ var log = logger.New("workflow-manager")
 
 // JobManager in the interface for creating, stopping and checking status for Jobs (workflow runs)
 type JobManager interface {
-	CreateJob(def resources.WorkflowDefinition, input []string, namspace string) (*resources.Job, error)
+	CreateJob(def resources.WorkflowDefinition, input []string, namespace string) (*resources.Job, error)
 	CancelJob(job *resources.Job, reason string) error
 	UpdateJobStatus(job *resources.Job) error
 }
@@ -240,7 +240,7 @@ func (jm BatchJobManager) scheduleTasks(job *resources.Job,
 	return nil
 }
 
-// getStateResources fetches JobDefinition URIs for each state 8
+// getStateResources fetches JobDefinition URIs for each state
 // from store.StateResource if namespace is set. If namespace is NOT
 // defined then StateResource objects are created with URI = state.Resource
 //

--- a/gen-go/models/job_input.go
+++ b/gen-go/models/job_input.go
@@ -17,6 +17,9 @@ type JobInput struct {
 	// data
 	Data []interface{} `json:"data"`
 
+	// namespace
+	Namespace string `json:"namespace,omitempty"`
+
 	// workflow
 	Workflow *WorkflowRef `json:"workflow,omitempty"`
 }

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Minimal Workflow orchestrator for AWS Batch",
   "main": "index.js",
   "dependencies": {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: b2e03f67e2d0d1cae3f1cb4a439a57648591e6f50678cff0c95c6c82b9f13d29
-updated: 2017-05-23T01:55:41.316857514Z
+updated: 2017-06-29T00:02:40.019186163Z
 imports:
 - name: github.com/afex/hystrix-go
   version: 39520ddd07a9d9a071d615f7476798659f5a3b89
@@ -8,9 +8,9 @@ imports:
   - hystrix/metric_collector
   - hystrix/rolling
 - name: github.com/asaskevich/govalidator
-  version: 872bb01704d183fe276bce6fa429408a87661998
+  version: 948702997351133e1cc5a1b5842313ca46deeb0d
 - name: github.com/aws/aws-sdk-go
-  version: 48385c808742c8f5f3d3a466d172a52b961ecd7c
+  version: 50762c1efc55dd2a05eac85fc170b0f65aeec28f
   subpackages:
   - aws
   - aws/awserr
@@ -28,6 +28,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
@@ -43,7 +44,7 @@ imports:
   - service/dynamodb/dynamodbiface
   - service/sts
 - name: github.com/Clever/discovery-go
-  version: 54b227302d6197cead03ad2bd0b9e9cc081c213c
+  version: b2114f3bdf1c55f030cf6d6d457478ccb18b9e9c
 - name: github.com/Clever/go-process-metrics
   version: ad2ae069c3b772e1cdc9eeb9375903368c85c329
   subpackages:
@@ -57,33 +58,31 @@ imports:
   subpackages:
   - spew
 - name: github.com/donovanhide/eventsource
-  version: fd1de70867126402be23c306e1ce32828455d85b
+  version: 158976d3210cd0ffba4301bc88b8bf4091bf1329
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+  version: 36da989cdc560b989d8f195aec46214d33665d20
 - name: github.com/go-openapi/analysis
-  version: d5a75b7d751ca3f11ad5d93cfe97405f2c3f6a47
+  version: 0473cb67199f68b8b7d90e641afd9e79ad36b851
 - name: github.com/go-openapi/errors
-  version: fc3f73a224499b047eda7191e5d22e1e9631e86f
+  version: 03cfca65330da08a5a440053faf994a3c682b5bf
 - name: github.com/go-openapi/jsonpointer
   version: 779f45308c19820f1a69e9a4cd965f496e0da10f
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/loads
-  version: 6bb6486231e079ea125c0f39994ed3d0c53399ed
-  subpackages:
-  - fmts
+  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
 - name: github.com/go-openapi/runtime
-  version: e66a4c4406028a04ddafd6002c378ffd3db7e52b
+  version: 2e9e988df6c290425033bacd425e008950c96be6
 - name: github.com/go-openapi/spec
-  version: 02fb9cd3430ed0581e0ceb4804d5d4b3cc702694
+  version: e51c28f07047ad90caff03f6450908720d337e0c
 - name: github.com/go-openapi/strfmt
   version: 93a31ef21ac23f317792fff78f9539219dd74619
 - name: github.com/go-openapi/swag
-  version: d5f8ebc3b1c55a4cf6489eeae7354f338cfe299e
+  version: e43299b4afa7bc7f22e5e82e3d48607230e4c177
 - name: github.com/go-openapi/validate
   version: 035dcd74f1f61e83debe1c22950dc53556e7e4b2
 - name: github.com/gogo/protobuf
@@ -130,13 +129,13 @@ imports:
 - name: github.com/magiconair/properties
   version: 0723e352fa358f9322c938cc2dadda874e9151a9
 - name: github.com/mailru/easyjson
-  version: db58e6f9072c545a3a24b8d44c51d81fff6dcb51
+  version: dffba8d13bbd998df17d8557570cdea0624b9d1d
   subpackages:
   - buffer
   - jlexer
   - jwriter
 - name: github.com/mitchellh/mapstructure
-  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+  version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/opentracing/basictracer-go
   version: 1b32af207119a14b1b231d451df3ed04a72efebf
   subpackages:
@@ -155,9 +154,9 @@ imports:
   subpackages:
   - difflib
 - name: github.com/PuerkitoBio/purell
-  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
+  version: b938d81255b5473c57635324295cb0fe398c7a58
 - name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/spf13/afero
@@ -167,11 +166,11 @@ imports:
 - name: github.com/spf13/cast
   version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
 - name: github.com/spf13/cobra
-  version: 6e91dded25d73176bf7f60b40dd7aa1f0bf9be8d
+  version: ca57f0f5dba473a8a58765d16d7e811fb8027add
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/spf13/viper
   version: 651d9d916abc3c3d6a91a12549495caba5edffd2
 - name: github.com/stretchr/testify
@@ -184,9 +183,9 @@ imports:
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
-  version: ff0417f4272e480246b4507459b3f6ae721a87ac
+  version: a55c211c418162597a32c74c7230f81adb5ad616
 - name: golang.org/x/net
-  version: b336a971b799939dd16ae9b1df8334cb8b977c4d
+  version: 5b58a9c3e1690d33a592e5b791638e25eb9b3f70
   subpackages:
   - context
   - context/ctxhttp
@@ -201,9 +200,11 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: f28f36722d5ef2f9655ad3de1f248e3e52ad5ebd
+  version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
   subpackages:
+  - secure/bidirule
   - transform
+  - unicode/bidi
   - unicode/norm
   - width
 - name: google.golang.org/grpc
@@ -224,10 +225,6 @@ imports:
   version: 056c92dcc68b40c5d6045f755197b3776f914154
   subpackages:
   - logger
-- name: gopkg.in/Clever/kayvee-go.v5
-  version: 865aa5e4bbe8e274c69accd53f0b1e2ecc484cd8
-  subpackages:
-  - logger
 - name: gopkg.in/Clever/kayvee-go.v6
   version: 096364e316a52652d3493be702d8105d8d01db84
   subpackages:
@@ -242,5 +239,5 @@ imports:
 - name: gopkg.in/tylerb/graceful.v1
   version: 4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports: []

--- a/handler.go
+++ b/handler.go
@@ -180,7 +180,7 @@ func (wm WorkflowManager) StartJobForWorkflow(ctx context.Context, input *models
 		data = jsonToArgs(input.Data)
 	}
 
-	job, err := wm.manager.CreateJob(workflow, data)
+	job, err := wm.manager.CreateJob(workflow, data, input.Namespace)
 	if err != nil {
 		return &models.Job{}, err
 	}

--- a/resources/tasks.go
+++ b/resources/tasks.go
@@ -27,19 +27,21 @@ type TaskDetail struct {
 // Task represents an active State and as part of a Job
 type Task struct {
 	TaskDetail
-	ID    string
-	Name  string
-	Input []string
-	State string
+	ID            string
+	Name          string
+	Input         []string
+	State         string
+	StateResource StateResource
 }
 
 // NewTask creates a new Task
-func NewTask(id, name, state string, input []string) *Task {
+func NewTask(id, name, state string, stateResource StateResource, input []string) *Task {
 	return &Task{
-		ID:    id,
-		Name:  name,
-		Input: input,
-		State: state,
+		ID:            id,
+		Name:          name,
+		Input:         input,
+		State:         state,
+		StateResource: stateResource,
 		TaskDetail: TaskDetail{
 			Status: TaskStatusCreated,
 		},

--- a/resources/workflows.go
+++ b/resources/workflows.go
@@ -195,7 +195,7 @@ func (ws *WorkerState) IsEnd() bool {
 	return ws.End
 }
 
-// Resource the name of the resource that needs to be executed as
+// Resource is the name of the resource that needs to be executed as
 // part of a task for this State
 func (ws *WorkerState) Resource() string {
 	return ws.ResourceStr

--- a/resources/workflows.go
+++ b/resources/workflows.go
@@ -195,7 +195,7 @@ func (ws *WorkerState) IsEnd() bool {
 	return ws.End
 }
 
-// Resource the resource that needs to be executed as
+// Resource the name of the resource that needs to be executed as
 // part of a task for this State
 func (ws *WorkerState) Resource() string {
 	return ws.ResourceStr

--- a/swagger.yml
+++ b/swagger.yml
@@ -368,6 +368,8 @@ definitions:
         $ref: '#/definitions/WorkflowRef'
       data:
         type: array
+      namespace:
+        type: string
 
   WorkflowRef:
     type: object


### PR DESCRIPTION
- providing a namespace to the CreateJob endpoint performs a lookup in
the StateResource table to lookup the BatchJobDefinitionARN.

- leaving the namespace blank (== "") mirrors the current behavior where
it is expected that the Workflow.State.Resource is set to a valid ARN.

- Another minor change here is to add StateResource to the `Task` model.
This will allow us to lookup the JobDefinitionARN used to create the
task.

----------------

- [ ] Update swagger.yml version
- [ ] Run "make generate"
- [ ] After merging, add a github tag to your merge commit
