### PR TITLE
handle TaskStatusAborted and TaskStatusUserAborted

### DIFF
--- a/executor/job_manager_test.go
+++ b/executor/job_manager_test.go
@@ -116,6 +116,25 @@ func TestUpdateJobStatus(t *testing.T) {
 	t.Log("Job is FAILED if any task FAILS")
 	assert.Nil(t, err)
 	assert.Equal(t, job.Status, resources.Failed)
+
+	// mark tasks as aborted, this should still mean the job is failed
+	for _, task := range job.Tasks {
+		mockClient.tasks[task.ID].SetStatus(resources.TaskStatusAborted)
+	}
+	err = jm.UpdateJobStatus(job)
+	t.Log("Job is FAILED if all tasks are aborted")
+	assert.Nil(t, err)
+	assert.Equal(t, job.Status, resources.Failed)
+
+	// mark a task as user-aborted, this should still mean the job is cancelled
+	for _, task := range job.Tasks {
+		mockClient.tasks[task.ID].SetStatus(resources.TaskStatusUserAborted)
+		break
+	}
+	err = jm.UpdateJobStatus(job)
+	t.Log("Job is CANCELLED if any task is user aborted")
+	assert.Nil(t, err)
+	assert.Equal(t, job.Status, resources.Cancelled)
 }
 
 // TestCancelUpdates ensures that a cancelling a job works


### PR DESCRIPTION
When AWS Batch hits a `container-pull` or `container-start` issue it immediately marks all tasks as `Failed` without `Starting`. This is marked as `TaskStatusAborted` in `workflow-manager`.

This change adds `Job.Status` handling for all tasks getting marked as `TaskStatusAborted` or if any task is `TaskStausAborted` outside of `workflow-manager` (e.g. through the AWS console or CLI).
