### PR TITLE
JobInput.Data should be []string not []interface{}

### DIFF
--- a/gen-go/models/job_input.go
+++ b/gen-go/models/job_input.go
@@ -15,7 +15,7 @@ import (
 type JobInput struct {
 
 	// data
-	Data []interface{} `json:"data"`
+	Data []string `json:"data"`
 
 	// namespace
 	Namespace string `json:"namespace,omitempty"`
@@ -31,6 +31,11 @@ type JobInput struct {
 func (m *JobInput) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateData(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateWorkflow(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -39,6 +44,15 @@ func (m *JobInput) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *JobInput) validateData(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Data) { // not required
+		return nil
+	}
+
 	return nil
 }
 

--- a/handler.go
+++ b/handler.go
@@ -179,10 +179,9 @@ func (wm WorkflowManager) StartJobForWorkflow(ctx context.Context, input *models
 		return &models.Job{}, err
 	}
 
-	var data []string
+	data := []string{}
 	if input.Data != nil {
-		// convert from []interface{} to []string (i.e. flattened json string array)
-		data = jsonToArgs(input.Data)
+		data = input.Data
 	}
 
 	job, err := wm.manager.CreateJob(workflow, data, input.Namespace, input.Queue)
@@ -232,16 +231,6 @@ func (wm WorkflowManager) CancelJob(ctx context.Context, input *models.CancelJob
 	}
 
 	return wm.manager.CancelJob(&job, input.Reason.Reason)
-}
-
-func jsonToArgs(data []interface{}) []string {
-	args := []string{}
-	for _, v := range data {
-		if arg, ok := v.(string); ok {
-			args = append(args, arg)
-		}
-	}
-	return args
 }
 
 // TODO: the functions below should probably just be functions on the respective resources.<Struct>

--- a/swagger.yml
+++ b/swagger.yml
@@ -390,6 +390,8 @@ definitions:
         $ref: '#/definitions/WorkflowRef'
       data:
         type: array
+        items:
+          type: string
       namespace:
         type: string
       queue:


### PR DESCRIPTION
We have standardized on using `[]string` as the data input for new Jobs but the `swagger.yml` did not specify `type: string`.

Followup: need to make sure none of the existing consumers break due to this change. 

Test with new client before merging 
- [ ] clever-cron
- [ ] mp-trigger
- [ ] ark

- [ ] Update swagger.yml version
- [ ] Run "make generate"
- [ ] After merging, add a github tag to your merge commit