### PR TITLE
Use TaskArn rather than Container Instance ARN

### DIFF
--- a/executor/batchclient/batch.go
+++ b/executor/batchclient/batch.go
@@ -109,8 +109,8 @@ func (be BatchExecutor) jobToTaskDetail(job *batch.JobDetail) (resources.TaskDet
 	if job.StoppedAt != nil {
 		stoppedAt = time.Unix(0, *job.StoppedAt*msToNs)
 	}
-	if job.Container != nil && job.Container.ContainerInstanceArn != nil {
-		containerArn = *job.Container.ContainerInstanceArn
+	if job.Container != nil && job.Container.TaskArn != nil {
+		containerArn = *job.Container.TaskArn
 	}
 
 	return resources.TaskDetail{

--- a/executor/batchclient/batch_test.go
+++ b/executor/batchclient/batch_test.go
@@ -20,9 +20,9 @@ func TestJobToTaskDetail(t *testing.T) {
 		JobDefinition: aws.String("arn:aws:batch:us-east-1:58111111125:job-definition/batchcli:1"),
 		JobId:         aws.String("5a4a8864-2b4e-4c7f-84c1-e3aae28b4ebd"),
 		Container: &batch.ContainerDetail{
-			MountPoints:          []*batch.MountPoint{},
-			Image:                aws.String("clever/batchcli:999999"),
-			ContainerInstanceArn: aws.String("arn:aws:ecs:us-east-1:589690932525:container-instance/460bbb01-93aa-4b5f-9740-0c1aed552691"),
+			MountPoints: []*batch.MountPoint{},
+			Image:       aws.String("clever/batchcli:999999"),
+			TaskArn:     aws.String("arn:aws:ecs:us-east-1:589690932525:task/97be0e7f-38f6-4675-9bac-82d36a3170d1"),
 			Environment: []*batch.KeyValuePair{
 				&batch.KeyValuePair{
 					Name:  aws.String("_BATCH_DEPENDENCIES"),


### PR DESCRIPTION
See https://clever.atlassian.net/browse/INFRA-2439

This change simply replaces the `ContainerInstanceArn` with the `TaskArn` for a job's container. I'm not convinced this value will be present, so I'd appreciate advice about how to test before deploying.