### PR TITLE
circle: enable dapple 'confirm-then-deploy'

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,8 @@ deployment:
     commands:
       - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
       - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
-      - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME
+      - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev confirm-then-deploy
+      - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy
       - $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN gen-js/
 general:
   build_dir: ../.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
Hooks workflow manager up to our CD system. Will send a prompt to Slack
to confirm deployments.