### PR TITLE
Split out config for the various dynamo tables.

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -5,7 +5,9 @@ env:
   - DEFAULT_BATCH_QUEUE
   - CUSTOM_BATCH_QUEUES # a JSON containing mappings from {"<name>":"<queue>",...}
   - AWS_DYNAMO_REGION
-  - AWS_DYNAMO_PREFIX
+  - AWS_DYNAMO_PREFIX_STATE_RESOURCES
+  - AWS_DYNAMO_PREFIX_WORKFLOW_DEFINITIONS
+  - AWS_DYNAMO_PREFIX_WORKFLOWS
 resources:
   cpu: 0.01
   max_mem: 0.02

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -14,35 +14,41 @@ import (
 )
 
 type DynamoDB struct {
-	ddb             dynamodbiface.DynamoDBAPI
-	tableNamePrefix string
+	ddb         dynamodbiface.DynamoDBAPI
+	tableConfig TableConfig
 }
 
-func New(ddb dynamodbiface.DynamoDBAPI, tableNamePrefix string) DynamoDB {
+type TableConfig struct {
+	PrefixStateResources      string
+	PrefixWorkflowDefinitions string
+	PrefixWorkflows           string
+}
+
+func New(ddb dynamodbiface.DynamoDBAPI, tableConfig TableConfig) DynamoDB {
 	return DynamoDB{
-		ddb:             ddb,
-		tableNamePrefix: tableNamePrefix,
+		ddb:         ddb,
+		tableConfig: tableConfig,
 	}
 }
 
 // latestWorkflowDefinitionsTable returns the name of the table that stores the latest version of every WorkflowDefinition
 func (d DynamoDB) latestWorkflowDefinitionsTable() string {
-	return fmt.Sprintf("%s-latest-workflow-definitions", d.tableNamePrefix)
+	return fmt.Sprintf("%s-latest-workflow-definitions", d.tableConfig.PrefixWorkflowDefinitions)
 }
 
 // workflowDefinitionsTable returns the name of the table that stores all WorkflowDefinitions
 func (d DynamoDB) workflowDefinitionsTable() string {
-	return fmt.Sprintf("%s-workflow-definitions", d.tableNamePrefix)
+	return fmt.Sprintf("%s-workflow-definitions", d.tableConfig.PrefixWorkflowDefinitions)
 }
 
 // workflowsTable returns the name of the table that stores workflows.
 func (d DynamoDB) workflowsTable() string {
-	return fmt.Sprintf("%s-workflows", d.tableNamePrefix)
+	return fmt.Sprintf("%s-workflows", d.tableConfig.PrefixWorkflows)
 }
 
 // stateResourcesTable returns the name of the table that stores stateResources.
 func (d DynamoDB) stateResourcesTable() string {
-	return fmt.Sprintf("%s-state-resources", d.tableNamePrefix)
+	return fmt.Sprintf("%s-state-resources", d.tableConfig.PrefixStateResources)
 }
 
 // dynamoItemsToWorkflowDefinitions takes the Items from a Query or Scan result and decodes it into an array of workflow definitions

--- a/store/dynamodb/dynamodb_store_test.go
+++ b/store/dynamodb/dynamodb_store_test.go
@@ -19,7 +19,11 @@ func TestDynamoDBStore(t *testing.T) {
 			Credentials: credentials.NewStaticCredentials("id", "secret", "token"),
 		},
 	})))
-	s := New(svc, "test")
+	s := New(svc, TableConfig{
+		PrefixStateResources:      "test",
+		PrefixWorkflowDefinitions: "test",
+		PrefixWorkflows:           "test",
+	})
 	if err := s.InitTables(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is so we can read from the prod definitions and state resources tables in local/staging, but continue to write to the staging workflows table.

Config added in https://github.com/Clever/ark-config/pull/604

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
- [N/A] After merging, add a github tag to your merge commit
