### PR TITLE
remove polling loop on individual workflows

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -184,7 +184,8 @@ func (wm BatchWorkflowManager) checkPendingWorkflows() error {
 		wm.store.UnlockWorkflow(wfLockedID)
 	}()
 
-	if wf, err := wm.store.GetWorkflowByID(wfLockedID); err != nil {
+	wf, err := wm.store.GetWorkflowByID(wfLockedID)
+	if err != nil {
 		return err
 	}
 

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -174,23 +174,21 @@ func (wm BatchWorkflowManager) checkPendingWorkflows() error {
 	}
 
 	if wfLockedID == "" {
-		log.InfoD("check-pending-workflows-noop", logger.M{})
+		log.InfoD("pending-workflows-noop", logger.M{"pending": len(wfIDs)})
 		return nil
 	}
 
-	log.InfoD("check-pending-workflow-locked", logger.M{"id": wfLockedID})
+	log.InfoD("pending-workflows-locked", logger.M{"id": wfLockedID})
 	defer func() {
-		log.InfoD("check-pending-workflow-unlocked", logger.M{"id": wfLockedID})
+		log.InfoD("pending-workflows-unlocked", logger.M{"id": wfLockedID})
 		wm.store.UnlockWorkflow(wfLockedID)
 	}()
 
 	if wf, err := wm.store.GetWorkflowByID(wfLockedID); err != nil {
 		return err
-	} else if err := wm.UpdateWorkflowStatus(&wf); err != nil {
-		return err
 	}
 
-	return nil
+	return wm.UpdateWorkflowStatus(&wf)
 }
 
 func (wm BatchWorkflowManager) CancelWorkflow(workflow *resources.Workflow, reason string) error {

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -185,7 +185,9 @@ func (wm BatchWorkflowManager) checkPendingWorkflows() error {
 	log.InfoD("pending-workflows-locked", logger.M{"id": wfLockedID})
 	defer func() {
 		log.InfoD("pending-workflows-unlocked", logger.M{"id": wfLockedID})
-		wm.store.UnlockWorkflow(wfLockedID)
+		if err := wm.store.UnlockWorkflow(wfLockedID); err != nil {
+			log.ErrorD("pending-workflows-unlock-error", logger.M{"error": err.Error()})
+		}
 	}()
 
 	wf, err := wm.store.GetWorkflowByID(wfLockedID)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7579344b2cf74e7467fd42bb0f08255798c6b30b3a596bdae9bca4feb155c74f
-updated: 2017-09-15T04:24:29.339242735Z
+hash: 8b1ea624b45c38ea42442b26fc5352b7e7721ce92a364469f2ec1f62b5f5dec5
+updated: 2017-09-16T04:08:53.264215747Z
 imports:
 - name: github.com/afex/hystrix-go
   version: f118cd938f786d24f46cc307981d8f63b7951020
@@ -10,7 +10,7 @@ imports:
 - name: github.com/asaskevich/govalidator
   version: 73945b6115bfbbcc57d89b7316e28109364124e1
 - name: github.com/aws/aws-sdk-go
-  version: cbd6949bf5611b581f686f8fbacd7858c7464767
+  version: 88849eea79e8e48241987b1f0a11a7a0dcbb7716
   subpackages:
   - aws
   - aws/awserr
@@ -42,7 +42,6 @@ imports:
   - service/dynamodb
   - service/dynamodb/dynamodbattribute
   - service/dynamodb/dynamodbiface
-  - service/sqs
   - service/sts
 - name: github.com/Clever/discovery-go
   version: 2e485eaaf026d527548740ceff178c8859fcaa07
@@ -89,7 +88,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/golang/mock
-  version: 18f6dd13ccdd227b8ebc546ca95cd62a02f3970c
+  version: cd1f5ca28400ea81f03fbc828a052ab46c33fcf9
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
@@ -154,12 +153,12 @@ imports:
 - name: github.com/xeipuuv/gojsonschema
   version: 3f523f4c14b6e925da10475eb0447c2f28614aac
 - name: github.com/zencoder/ddbsync
-  version: ccb84f8ad168556f70f690882b20d6abaed94d0a
+  version: 83dd4ef1834424d47a7cde4a7f4361cfabbd7564
   repo: git@github.com:Clever/ddbsync.git
   subpackages:
   - models
 - name: golang.org/x/net
-  version: 859d1a86bb617c0c20d154590c3c5d3fcb670b07
+  version: 8351a756f30f1297fe94bbf4b767ec589c6ea6d0
   subpackages:
   - context
   - context/ctxhttp
@@ -170,7 +169,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: 14c0d48ead0cd47e3104ada247d91be04afc7a5a
+  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
   subpackages:
   - secure/bidirule
   - transform

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,16 @@
-hash: c567d2d5c342b0c3a52b56fcfdbc56ff706290ff5817cc4e8ea46aa4fb959e2f
-updated: 2017-08-02T23:57:11.300483723Z
+hash: 7579344b2cf74e7467fd42bb0f08255798c6b30b3a596bdae9bca4feb155c74f
+updated: 2017-09-15T04:24:29.339242735Z
 imports:
 - name: github.com/afex/hystrix-go
-  version: 39520ddd07a9d9a071d615f7476798659f5a3b89
+  version: f118cd938f786d24f46cc307981d8f63b7951020
   subpackages:
   - hystrix
   - hystrix/metric_collector
   - hystrix/rolling
 - name: github.com/asaskevich/govalidator
-  version: aa5cce4a76edb1a5acecab1870c17abbffb5419e
+  version: 73945b6115bfbbcc57d89b7316e28109364124e1
 - name: github.com/aws/aws-sdk-go
-  version: b33b08175d12b795daa7726c5577b39d06a2551c
+  version: cbd6949bf5611b581f686f8fbacd7858c7464767
   subpackages:
   - aws
   - aws/awserr
@@ -42,15 +42,16 @@ imports:
   - service/dynamodb
   - service/dynamodb/dynamodbattribute
   - service/dynamodb/dynamodbiface
+  - service/sqs
   - service/sts
 - name: github.com/Clever/discovery-go
-  version: b2114f3bdf1c55f030cf6d6d457478ccb18b9e9c
+  version: 2e485eaaf026d527548740ceff178c8859fcaa07
 - name: github.com/Clever/go-process-metrics
-  version: 17c3da159c36ee2bbb4198c8eeada7f68184350f
+  version: 5944a49b5051ebcc10feb08724689740b4eefa28
   subpackages:
   - metrics
 - name: github.com/Clever/kayvee-go
-  version: 096364e316a52652d3493be702d8105d8d01db84
+  version: e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5
   subpackages:
   - logger
 - name: github.com/davecgh/go-spew
@@ -59,14 +60,12 @@ imports:
   - spew
 - name: github.com/donovanhide/eventsource
   version: b8f31a59085e69dd2678cf51840db2ac625cb741
-- name: github.com/fsnotify/fsnotify
-  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+  version: c787282c39ac1fc618827141a1f762240def08a3
 - name: github.com/go-openapi/analysis
-  version: 0473cb67199f68b8b7d90e641afd9e79ad36b851
+  version: 8ed83f2ea9f00f945516462951a288eaa68bf0d6
 - name: github.com/go-openapi/errors
   version: 03cfca65330da08a5a440053faf994a3c682b5bf
 - name: github.com/go-openapi/jsonpointer
@@ -76,25 +75,25 @@ imports:
 - name: github.com/go-openapi/loads
   version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
 - name: github.com/go-openapi/runtime
-  version: 298d3440fe543eafb0aee85d89cd5db918fb3ec3
+  version: bf2ff8f7150788b1c7256abb0805ba0410cbbabb
 - name: github.com/go-openapi/spec
-  version: 9cf697d99bf904e29363382a2e8c23dde5c8d377
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
 - name: github.com/go-openapi/strfmt
-  version: 93a31ef21ac23f317792fff78f9539219dd74619
+  version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
 - name: github.com/go-openapi/swag
   version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/go-openapi/validate
-  version: 8a82927c942c94794a5cd8b8b50ce2f48a955c0c
+  version: 901ab082554d18fd6a99cc3a4bde6469e58d4cf6
 - name: github.com/gogo/protobuf
-  version: 98066786c62ce5b2c49aba8527b914a014aaf49f
+  version: 2adc21fd136931e0388e278825291678e1d98309
   subpackages:
   - proto
 - name: github.com/golang/mock
-  version: 13f360950a79f5864a972c786a10a50e44b69541
+  version: 18f6dd13ccdd227b8ebc546ca95cd62a02f3970c
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
+  version: 11b8df160996e00fd4b55cbaafb3d84ec6d50fa8
   subpackages:
   - proto
   - ptypes
@@ -102,26 +101,13 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/gorilla/context
-  version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
-- name: github.com/hashicorp/hcl
-  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
-  subpackages:
-  - hcl/ast
-  - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
-  - hcl/token
-  - json/parser
-  - json/scanner
-  - json/token
-- name: github.com/inconshreveable/mousetrap
-  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/kardianos/osext
-  version: c2c54e542fb797ad986b31721e1baedf214ca413
+  version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/lightstep/lightstep-tracer-go
   version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
   subpackages:
@@ -129,10 +115,8 @@ imports:
   - lightstep_thrift
   - thrift_0_9_2/lib/go/thrift
   - thrift_rpc
-- name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
 - name: github.com/mailru/easyjson
-  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
+  version: 2a92e673c9a6302dd05c3a691ae1f24aef46457d
   subpackages:
   - buffer
   - jlexer
@@ -148,32 +132,16 @@ imports:
   subpackages:
   - ext
   - log
-- name: github.com/pelletier/go-toml
-  version: 69d355db5304c0f7f809a2edc054553e7142f016
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/PuerkitoBio/purell
-  version: b938d81255b5473c57635324295cb0fe398c7a58
+  version: f619812e3caf603a8df60a7ec6f2654b703189ef
 - name: github.com/PuerkitoBio/urlesc
-  version: bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5
+  version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/spf13/afero
-  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
-  subpackages:
-  - mem
-- name: github.com/spf13/cast
-  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
-- name: github.com/spf13/cobra
-  version: c46add8a652801b61513ad36c56759f302fbb028
-- name: github.com/spf13/jwalterweatherman
-  version: 0efa5202c04663c757d84f90f5219c1250baf94f
-- name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
-- name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
@@ -184,9 +152,14 @@ imports:
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
-  version: 702b404897d4364af44dc8dcabc9815947942325
+  version: 3f523f4c14b6e925da10475eb0447c2f28614aac
+- name: github.com/zencoder/ddbsync
+  version: ccb84f8ad168556f70f690882b20d6abaed94d0a
+  repo: git@github.com:Clever/ddbsync.git
+  subpackages:
+  - models
 - name: golang.org/x/net
-  version: 5602c733f70afc6dcec6766be0d5034d4c4f14de
+  version: 859d1a86bb617c0c20d154590c3c5d3fcb670b07
   subpackages:
   - context
   - context/ctxhttp
@@ -196,12 +169,8 @@ imports:
   - internal/timeseries
   - lex/httplex
   - trace
-- name: golang.org/x/sys
-  version: e312636bdaa2fac4f0acde9d17ab9fbad2b4ad10
-  subpackages:
-  - unix
 - name: golang.org/x/text
-  version: 836efe42bb4aa16aaa17b9c155d8813d336ed720
+  version: 14c0d48ead0cd47e3104ada247d91be04afc7a5a
   subpackages:
   - secure/bidirule
   - transform
@@ -209,31 +178,30 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/genproto
-  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: b463cc3276f7d8a556664a893915d0f49d449a4d
+  version: bb78878767b96d411e740439ac820f118e95ae2f
   subpackages:
+  - balancer
   - codes
+  - connectivity
   - credentials
-  - grpclb/grpc_lb_v1
+  - grpclb/grpc_lb_v1/messages
   - grpclog
   - internal
   - keepalive
   - metadata
   - naming
   - peer
+  - resolver
   - stats
   - status
   - tap
   - transport
-- name: gopkg.in/Clever/kayvee-go.v3
-  version: 056c92dcc68b40c5d6045f755197b3776f914154
-  subpackages:
-  - logger
 - name: gopkg.in/Clever/kayvee-go.v6
-  version: 096364e316a52652d3493be702d8105d8d01db84
+  version: e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5
   subpackages:
   - logger
   - middleware
@@ -246,5 +214,5 @@ imports:
 - name: gopkg.in/tylerb/graceful.v1
   version: 4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,3 +27,6 @@ import:
   version: master
   subpackages:
   - gomock
+- package: github.com/zencoder/ddbsync
+  version: attempt-lock
+  repo: git@github.com:Clever/ddbsync.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,5 +28,5 @@ import:
   subpackages:
   - gomock
 - package: github.com/zencoder/ddbsync
-  version: attempt-lock
-  repo: git@github.com:Clever/ddbsync.git
+  version: 83dd4ef
+  repo: git@github.com:Clever/ddbsync.git # use our fork which adds a couple of methods

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -540,8 +540,8 @@ func (d DynamoDB) GetWorkflowByID(id string) (resources.Workflow, error) {
 	return workflow, nil
 }
 
-// GetWorkflows returns the last 10 workflows for a workflow.
-// It uses a global secondary index on the workflow name + created time for a workflow.
+// GetWorkflows returns the last 10 workflows for a workflow definition.
+// It uses a global secondary index on the workflow definition name + created time for a workflow.
 func (d DynamoDB) GetWorkflows(workflowName string) ([]resources.Workflow, error) {
 	var workflows []resources.Workflow
 	query, err := ddbWorkflowSecondaryKeyWorkflowDefinitionCreatedAt{

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -12,11 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/zencoder/ddbsync"
 )
 
 type DynamoDB struct {
 	ddb         dynamodbiface.DynamoDBAPI
 	tableConfig TableConfig
+	lockDB      ddbsync.DBer
 }
 
 type TableConfig struct {
@@ -26,10 +28,17 @@ type TableConfig struct {
 }
 
 func New(ddb dynamodbiface.DynamoDBAPI, tableConfig TableConfig) DynamoDB {
-	return DynamoDB{
+	d := DynamoDB{
 		ddb:         ddb,
 		tableConfig: tableConfig,
 	}
+	d.lockDB = ddbsync.NewDatabaseFromDDBAPI(ddb, d.locksTable())
+	return d
+}
+
+// locksTable returns the name of the table that stores the locks on workflows.
+func (d DynamoDB) locksTable() string {
+	return fmt.Sprintf("%s-locks", d.tableConfig.PrefixWorkflows)
 }
 
 // latestWorkflowDefinitionsTable returns the name of the table that stores the latest version of every WorkflowDefinition
@@ -177,6 +186,29 @@ func (d DynamoDB) InitTables() error {
 			WriteCapacityUnits: aws.Int64(1),
 		},
 		TableName: aws.String(d.stateResourcesTable()),
+	}); err != nil {
+		return err
+	}
+
+	// create locks table. This should probably be exposed in ddbsync
+	if _, err := d.ddb.CreateTable(&dynamodb.CreateTableInput{
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String("Name"),
+				AttributeType: aws.String(dynamodb.ScalarAttributeTypeS),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String("Name"),
+				KeyType:       aws.String(dynamodb.KeyTypeHash),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(1),
+			WriteCapacityUnits: aws.Int64(1),
+		},
+		TableName: aws.String(d.locksTable()),
 	}); err != nil {
 		return err
 	}
@@ -583,4 +615,23 @@ func (d DynamoDB) GetPendingWorkflowIDs() ([]string, error) {
 		pendingWorkflowIDs = append(pendingWorkflowIDs, pendingWorkflow.ID)
 	}
 	return pendingWorkflowIDs, nil
+}
+
+// LockWorkflow acquires a lock on modifying a workflow.
+func (s DynamoDB) LockWorkflow(id string) error {
+	mu := ddbsync.NewMutex(id, 30 /* seconds */, s.lockDB, 0 /* no reattempts, so irrelevant */)
+	if err := mu.AttemptLock(); err != nil {
+		if err == ddbsync.ErrLockAlreadyHeld {
+			return store.ErrWorkflowLocked
+		}
+		return err
+	}
+	return nil
+}
+
+// UnlockWorkflow releases a lock (if it exists) on modifying a workflow.
+func (s DynamoDB) UnlockWorkflow(id string) error {
+	mu := ddbsync.NewMutex(id, 30 /* seconds */, s.lockDB, 0 /* no reattempts, so irrelevant */)
+	mu.Unlock()
+	return nil
 }

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -12,6 +12,7 @@ import (
 type MemoryStore struct {
 	workflowDefinitions map[string][]resources.WorkflowDefinition
 	workflows           map[string]resources.Workflow
+	workflowsLocked     map[string]struct{}
 	stateResources      map[string]resources.StateResource
 }
 
@@ -25,6 +26,7 @@ func New() MemoryStore {
 	return MemoryStore{
 		workflowDefinitions: map[string][]resources.WorkflowDefinition{},
 		workflows:           map[string]resources.Workflow{},
+		workflowsLocked:     map[string]struct{}{},
 		stateResources:      map[string]resources.StateResource{},
 	}
 }
@@ -193,4 +195,17 @@ func (s MemoryStore) GetPendingWorkflowIDs() ([]string, error) {
 	}
 	return pendingWorkflowIDs, nil
 
+}
+
+func (s MemoryStore) LockWorkflow(id string) error {
+	if _, ok := s.workflowsLocked[id]; ok {
+		return store.ErrWorkflowLocked
+	}
+	s.workflowsLocked[id] = struct{}{}
+	return nil
+}
+
+func (s MemoryStore) UnlockWorkflow(id string) error {
+	delete(s.workflowsLocked, id)
+	return nil
 }

--- a/store/memory/memory_store_test.go
+++ b/store/memory/memory_store_test.go
@@ -3,13 +3,10 @@ package memory
 import (
 	"testing"
 
+	"github.com/Clever/workflow-manager/store"
 	"github.com/Clever/workflow-manager/store/tests"
 )
 
 func TestMemoryStore(t *testing.T) {
-	s := New()
-	// GetWorkflowDefinitions does a primitive length check of the number of workflows received
-	// We should run it first for it to pass
-
-	tests.RunStoreTests(s, t)
+	tests.RunStoreTests(t, func() store.Store { return New() })
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
@@ -25,7 +26,12 @@ type Store interface {
 	GetWorkflowByID(id string) (resources.Workflow, error)
 	GetWorkflows(workflowName string) ([]resources.Workflow, error)
 	GetPendingWorkflowIDs() ([]string, error)
+	LockWorkflow(id string) error
+	UnlockWorkflow(id string) error
 }
+
+// ErrWorkflowLocked is returned from LockWorfklow in the case of the workflow already being locked.
+var ErrWorkflowLocked = errors.New("workflow already locked")
 
 type ConflictError struct {
 	name string

--- a/store/store.go
+++ b/store/store.go
@@ -24,6 +24,7 @@ type Store interface {
 	UpdateWorkflow(workflow resources.Workflow) error
 	GetWorkflowByID(id string) (resources.Workflow, error)
 	GetWorkflows(workflowName string) ([]resources.Workflow, error)
+	GetPendingWorkflowIDs() ([]string, error)
 }
 
 type ConflictError struct {


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2300

Before this change, workflow-manager would initiate a goroutine on workflow submission that monitored the workflow for updates. This introduced state to workflow-manager that is lost on restart, similar to what we have today with gearman-admin.

This PR removes the polling loop on individual workflows and replaces it with a polling loop that is running constantly looking for workflows in a pending state. When it finds one, it locks it, and then attempts to perform an update on it.

There are roughly three parts to this change, broken down into three commits:
1) add a `GetPendingWorkflows` method to the store interface that returns workflows that are in a queued or running state.
2) add a `LockWorkflow` and `UnlockWorkflow` that lets you lock a workflow for updating, and unlock it when you're done.
3) replace the polling loop spawned on worfklow creation with a polling loop spawned on startup. It uses `GetPendingWorkflows` to find a workflow to check, then uses `LockWorkflow` to lock it, and then uses the existing method for updating a workflow.

I've added tests to the `store` package, and manually tested the polling loop in a couple of ways locally:
- Running 2 instances of workflow-manager locally, submitting a workflow, seeing its status proceed from queued -> running -> complete.
- Running 2 instances of workflow-manager locally, submitting a workflow, killing instances of workflow-manager, re-spawning them, seeing it pick up on the pending workflow and update its status.