### PR TITLE
Expose per-job inputs and outputs

### DIFF
--- a/executor/workflow_manager_test.go
+++ b/executor/workflow_manager_test.go
@@ -23,9 +23,11 @@ func (be *mockBatchClient) SubmitWorkflow(name string, definition string, depend
 	}
 	jobID := uuid.NewV4().String()
 	be.jobs[jobID] = &resources.Job{
-		ID:    jobID,
-		Name:  name,
-		Input: input,
+		ID:   jobID,
+		Name: name,
+		JobDetail: resources.JobDetail{
+			Input: input,
+		},
 	}
 
 	return jobID, nil

--- a/gen-go/models/job.go
+++ b/gen-go/models/job.go
@@ -23,8 +23,17 @@ type Job struct {
 	// created at
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
+	// dependency ids
+	DependencyIds []string `json:"dependencyIDs"`
+
 	// id
 	ID string `json:"id,omitempty"`
+
+	// input
+	Input []string `json:"input"`
+
+	// output
+	Output string `json:"output,omitempty"`
 
 	// started at
 	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
@@ -47,6 +56,16 @@ func (m *Job) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAttempts(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateDependencyIds(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateInput(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -76,6 +95,24 @@ func (m *Job) validateAttempts(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Job) validateDependencyIds(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DependencyIds) { // not required
+		return nil
+	}
+
+	return nil
+}
+
+func (m *Job) validateInput(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Input) { // not required
+		return nil
 	}
 
 	return nil

--- a/gen-go/models/job.go
+++ b/gen-go/models/job.go
@@ -23,9 +23,6 @@ type Job struct {
 	// created at
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
 
-	// dependency ids
-	DependencyIds []string `json:"dependencyIDs"`
-
 	// id
 	ID string `json:"id,omitempty"`
 
@@ -33,7 +30,7 @@ type Job struct {
 	Input []string `json:"input"`
 
 	// output
-	Output string `json:"output,omitempty"`
+	Output []string `json:"output"`
 
 	// started at
 	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
@@ -60,12 +57,12 @@ func (m *Job) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDependencyIds(formats); err != nil {
+	if err := m.validateInput(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
 
-	if err := m.validateInput(formats); err != nil {
+	if err := m.validateOutput(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -100,18 +97,18 @@ func (m *Job) validateAttempts(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Job) validateDependencyIds(formats strfmt.Registry) error {
+func (m *Job) validateInput(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.DependencyIds) { // not required
+	if swag.IsZero(m.Input) { // not required
 		return nil
 	}
 
 	return nil
 }
 
-func (m *Job) validateInput(formats strfmt.Registry) error {
+func (m *Job) validateOutput(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Input) { // not required
+	if swag.IsZero(m.Output) { // not required
 		return nil
 	}
 

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Minimal Workflow orchestrator for AWS Batch",
   "main": "index.js",
   "dependencies": {

--- a/handler.go
+++ b/handler.go
@@ -308,15 +308,18 @@ func apiWorkflowFromStore(workflow resources.Workflow) *models.Workflow {
 	jobs := []*models.Job{}
 	for _, job := range workflow.Jobs {
 		jobs = append(jobs, &models.Job{
-			ID:           job.ID,
-			CreatedAt:    strfmt.DateTime(job.CreatedAt),
-			StartedAt:    strfmt.DateTime(job.StartedAt),
-			StoppedAt:    strfmt.DateTime(job.StoppedAt),
-			State:        job.State,
-			Status:       string(job.Status),
-			StatusReason: job.StatusReason,
-			Container:    job.ContainerId,
-			Attempts:     job.Attempts,
+			ID:            job.ID,
+			Attempts:      job.Attempts,
+			Container:     job.ContainerId,
+			CreatedAt:     strfmt.DateTime(job.CreatedAt),
+			DependencyIds: job.DependencyIDs,
+			Input:         job.Input,
+			Output:        job.Output,
+			StartedAt:     strfmt.DateTime(job.StartedAt),
+			State:         job.State,
+			Status:        string(job.Status),
+			StatusReason:  job.StatusReason,
+			StoppedAt:     strfmt.DateTime(job.StoppedAt),
 		})
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -308,18 +308,17 @@ func apiWorkflowFromStore(workflow resources.Workflow) *models.Workflow {
 	jobs := []*models.Job{}
 	for _, job := range workflow.Jobs {
 		jobs = append(jobs, &models.Job{
-			ID:            job.ID,
-			Attempts:      job.Attempts,
-			Container:     job.ContainerId,
-			CreatedAt:     strfmt.DateTime(job.CreatedAt),
-			DependencyIds: job.DependencyIDs,
-			Input:         job.Input,
-			Output:        job.Output,
-			StartedAt:     strfmt.DateTime(job.StartedAt),
-			State:         job.State,
-			Status:        string(job.Status),
-			StatusReason:  job.StatusReason,
-			StoppedAt:     strfmt.DateTime(job.StoppedAt),
+			ID:           job.ID,
+			Attempts:     job.Attempts,
+			Container:    job.ContainerId,
+			CreatedAt:    strfmt.DateTime(job.CreatedAt),
+			Input:        job.Input,
+			Output:       job.Output,
+			StartedAt:    strfmt.DateTime(job.StartedAt),
+			State:        job.State,
+			Status:       string(job.Status),
+			StatusReason: job.StatusReason,
+			StoppedAt:    strfmt.DateTime(job.StoppedAt),
 		})
 	}
 

--- a/resources/jobs.go
+++ b/resources/jobs.go
@@ -20,13 +20,17 @@ const (
 )
 
 type JobDetail struct {
-	CreatedAt    time.Time
-	StartedAt    time.Time
-	StoppedAt    time.Time
-	ContainerId  string // identification string for the running container
-	StatusReason string
-	Status       JobStatus
-	Attempts     []*models.JobAttempt
+	Attempts      []*models.JobAttempt
+	ContainerId   string // identification string for the running container
+	CreatedAt     time.Time
+	DependencyIDs []string
+	Input         []string
+	Output        string
+	QueueName     string
+	StartedAt     time.Time
+	Status        JobStatus
+	StatusReason  string
+	StoppedAt     time.Time
 }
 
 // Job represents an active State and as part of a Job
@@ -34,7 +38,6 @@ type Job struct {
 	JobDetail
 	ID            string
 	Name          string
-	Input         []string
 	State         string
 	StateResource StateResource
 }
@@ -44,10 +47,10 @@ func NewJob(id, name, state string, stateResource StateResource, input []string)
 	return &Job{
 		ID:            id,
 		Name:          name,
-		Input:         input,
 		State:         state,
 		StateResource: stateResource,
 		JobDetail: JobDetail{
+			Input:  input,
 			Status: JobStatusCreated,
 		},
 	}
@@ -82,11 +85,15 @@ func (job *Job) StatusToInt() int {
 }
 
 func (job *Job) SetDetail(detail JobDetail) {
-	job.CreatedAt = detail.CreatedAt
-	job.StartedAt = detail.StartedAt
-	job.StoppedAt = detail.StoppedAt
+	job.Attempts = detail.Attempts
 	job.ContainerId = detail.ContainerId
+	job.CreatedAt = detail.CreatedAt
+	job.DependencyIDs = detail.DependencyIDs
+	job.Input = detail.Input
+	job.Output = detail.Output
+	job.QueueName = detail.QueueName
+	job.StartedAt = detail.StartedAt
 	job.Status = detail.Status
 	job.StatusReason = detail.StatusReason
-	job.Attempts = detail.Attempts
+	job.StoppedAt = detail.StoppedAt
 }

--- a/resources/jobs.go
+++ b/resources/jobs.go
@@ -25,7 +25,7 @@ type JobDetail struct {
 	CreatedAt     time.Time
 	DependencyIDs []string
 	Input         []string
-	Output        string
+	Output        []string
 	QueueName     string
 	StartedAt     time.Time
 	Status        JobStatus

--- a/resources/jobs.go
+++ b/resources/jobs.go
@@ -20,17 +20,16 @@ const (
 )
 
 type JobDetail struct {
-	Attempts      []*models.JobAttempt
-	ContainerId   string // identification string for the running container
-	CreatedAt     time.Time
-	DependencyIDs []string
-	Input         []string
-	Output        []string
-	QueueName     string
-	StartedAt     time.Time
-	Status        JobStatus
-	StatusReason  string
-	StoppedAt     time.Time
+	Attempts     []*models.JobAttempt
+	ContainerId  string // identification string for the running container
+	CreatedAt    time.Time
+	Input        []string
+	Output       []string
+	QueueName    string
+	StartedAt    time.Time
+	Status       JobStatus
+	StatusReason string
+	StoppedAt    time.Time
 }
 
 // Job represents an active State and as part of a Job
@@ -88,7 +87,6 @@ func (job *Job) SetDetail(detail JobDetail) {
 	job.Attempts = detail.Attempts
 	job.ContainerId = detail.ContainerId
 	job.CreatedAt = detail.CreatedAt
-	job.DependencyIDs = detail.DependencyIDs
 	job.Input = detail.Input
 	job.Output = detail.Output
 	job.QueueName = detail.QueueName

--- a/swagger.yml
+++ b/swagger.yml
@@ -388,13 +388,16 @@ definitions:
     properties:
       id:
         type: string
+      attempts:
+        type: array
+        items:
+          $ref: '#/definitions/JobAttempt'
+      Container:
+        type: string
       createdAt:
         type: string
         format: date-time
       startedAt:
-        type: string
-        format: date-time
-      stoppedAt:
         type: string
         format: date-time
       state:
@@ -403,12 +406,9 @@ definitions:
         type: string
       statusReason:
         type: string
-      Container:
+      stoppedAt:
         type: string
-      attempts:
-        type: array
-        items:
-          $ref: '#/definitions/JobAttempt'
+        format: date-time
 
   JobAttempt:
     type: object

--- a/swagger.yml
+++ b/swagger.yml
@@ -397,16 +397,14 @@ definitions:
       createdAt:
         type: string
         format: date-time
-      dependencyIDs:
-        type: array
-        items:
-          type: string
       input:
         type: array
         items:
           type: string
       output:
-        type: string
+        type: array
+        items:
+          type: string
       startedAt:
         type: string
         format: date-time

--- a/swagger.yml
+++ b/swagger.yml
@@ -7,7 +7,7 @@ info:
   # 2. merge the new clients, and, after merging, tag the commit with the version:
   #    git tag -a vX.Y.Z -m "vX.Y.Z"
   #    git push origin --tags
-  version: 0.4.0
+  version: 0.4.1
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -397,6 +397,16 @@ definitions:
       createdAt:
         type: string
         format: date-time
+      dependencyIDs:
+        type: array
+        items:
+          type: string
+      input:
+        type: array
+        items:
+          type: string
+      output:
+        type: string
       startedAt:
         type: string
         format: date-time


### PR DESCRIPTION
This adds `input` and `output` fields to the `Job` model used in API responses.
Exposing additional fields on the internal `Job` model and using that in the conversion to WAG model.

Implementation work is WIP in an upcoming PR. Just splitting these up for ease of review.

- [x] Update swagger.yml version
- [x] Run "make generate"
- [ ] After merging, add a github tag to your merge commit
