### PR TITLE
Filter/pagination implementation for getWorkflows API

### DIFF
--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -292,7 +292,7 @@ Get the latest versions of all available WorkflowDefinitions
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>Object</code> |  |
-| [params.limit] | <code>number</code> |  |
+| [params.limit] | <code>number</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |
 | [params.pageToken] | <code>string</code> |  |
 | [params.status] | <code>string</code> |  |
@@ -312,7 +312,7 @@ Get the latest versions of all available WorkflowDefinitions
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>Object</code> |  |
-| [params.limit] | <code>number</code> |  |
+| [params.limit] | <code>number</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |
 | [params.pageToken] | <code>string</code> |  |
 | [params.status] | <code>string</code> |  |

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -1461,7 +1461,7 @@ class WorkflowManager {
 
   /**
    * @param {Object} params
-   * @param {number} [params.limit]
+   * @param {number} [params.limit] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
    * @param {string} [params.status]
@@ -1605,7 +1605,7 @@ class WorkflowManager {
 
   /**
    * @param {Object} params
-   * @param {number} [params.limit]
+   * @param {number} [params.limit] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
    * @param {string} [params.status]

--- a/handler.go
+++ b/handler.go
@@ -208,7 +208,7 @@ func (h Handler) GetWorkflows(
 	input *models.GetWorkflowsInput,
 ) ([]models.Workflow, string, error) {
 	limit := WorkflowsPageSizeDefault
-	if input.Limit != nil {
+	if input.Limit != nil && *input.Limit > 0 {
 		limit = int(*input.Limit)
 	}
 	if limit > WorkflowsPageSizeMax {

--- a/handler.go
+++ b/handler.go
@@ -223,6 +223,12 @@ func (h Handler) GetWorkflows(
 		Status:         swag.StringValue(input.Status),
 	})
 	if err != nil {
+		if _, ok := err.(store.InvalidPageTokenError); ok {
+			return []models.Workflow{}, "", models.BadRequest{
+				Message: err.Error(),
+			}
+		}
+
 		return []models.Workflow{}, "", err
 	}
 

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -576,7 +576,7 @@ func (d DynamoDB) GetWorkflows(query *store.WorkflowQuery) ([]resources.Workflow
 
 	pageKey, err := ParsePageKey(query.PageToken)
 	if err != nil {
-		return workflows, nextPageToken, err
+		return workflows, nextPageToken, store.NewInvalidPageTokenError(err)
 	}
 	if pageKey != nil {
 		dbQuery.SetExclusiveStartKey(map[string]*dynamodb.AttributeValue(*pageKey))

--- a/store/dynamodb/page_key.go
+++ b/store/dynamodb/page_key.go
@@ -1,0 +1,63 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+// PageKey represents a dynamodb page start key.
+type PageKey map[string]*dynamodb.AttributeValue
+
+// NewPageKey returns a new PageKey object.
+func NewPageKey(pageKeyMap map[string]*dynamodb.AttributeValue) *PageKey {
+	if pageKeyMap == nil {
+		return nil
+	}
+
+	pageKey := PageKey(pageKeyMap)
+	return &pageKey
+}
+
+// ParsePageKey parses the given JSON representation of a PageKey.
+func ParsePageKey(parseKeyJSON string) (*PageKey, error) {
+	if parseKeyJSON == "" {
+		return nil, nil
+	}
+
+	pageKeyMap := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(parseKeyJSON), &pageKeyMap); err != nil {
+		return nil, fmt.Errorf("unable to de-serialize dynamodb page key: %v", err)
+	}
+
+	pageKey, err := dynamodbattribute.ConvertToMap(pageKeyMap)
+	if err != nil {
+		return nil, fmt.Errorf("unable to de-serialize dynamodb page key: %v", err)
+	}
+
+	return NewPageKey(pageKey), nil
+}
+
+// ToJSON returns a JSON string representation of the PageKey.
+func (k *PageKey) ToJSON() (string, error) {
+	pageKeyMap, err := k.toMap()
+	if err != nil {
+		return "", fmt.Errorf("unable to serialize dynamodb page key: %v", err)
+	}
+
+	pageKeyJSONBytes, err := json.Marshal(pageKeyMap)
+	if err != nil {
+		return "", fmt.Errorf("unable to serialize dynamodb page key: %v", err)
+	}
+
+	return string(pageKeyJSONBytes[:len(pageKeyJSONBytes)]), nil
+}
+
+// toMap returns a plain golang map respresentation of the PageKey.
+func (k *PageKey) toMap() (map[string]interface{}, error) {
+	pageKeyMap := map[string]interface{}{}
+	err := dynamodbattribute.ConvertFromMap(*k, &pageKeyMap)
+	return pageKeyMap, err
+}

--- a/store/dynamodb/page_key_test.go
+++ b/store/dynamodb/page_key_test.go
@@ -1,0 +1,38 @@
+package dynamodb
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPageKeySerializationRoundTrip(t *testing.T) {
+	pageKeyMap := map[string]interface{}{
+		"name": "Usain Bolt",
+		"100m": 9.58,
+		"200m": 19.19,
+	}
+	pageKeyDynamoAttributeMap, err := dynamodbattribute.ConvertToMap(pageKeyMap)
+	require.NoError(t, err)
+
+	pageKey := NewPageKey(pageKeyDynamoAttributeMap)
+	assert.Equal(t, pageKeyDynamoAttributeMap, map[string]*dynamodb.AttributeValue(*pageKey))
+
+	pageKeyJSON, err := pageKey.ToJSON()
+	require.NoError(t, err)
+
+	pageKeyRoundTripped, err := ParsePageKey(pageKeyJSON)
+	require.NoError(t, err)
+	assert.Equal(t, pageKey, pageKeyRoundTripped)
+}
+
+func TestPageKeyHandlesEmptyValues(t *testing.T) {
+	assert.Nil(t, NewPageKey(nil))
+
+	parsedPageKey, err := ParsePageKey("")
+	require.NoError(t, err)
+	assert.Nil(t, parsedPageKey)
+}

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/satori/go.uuid"
+
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
 )
@@ -172,8 +174,13 @@ func (s MemoryStore) GetWorkflows(
 
 	rangeStart := 0
 	if query.PageToken != "" {
+		lastWorkflowID, err := uuid.FromString(query.PageToken)
+		if err != nil {
+			return []resources.Workflow{}, "", store.NewInvalidPageTokenError(err)
+		}
+
 		for i, workflow := range workflows {
-			if workflow.ID == query.PageToken {
+			if workflow.ID == lastWorkflowID.String() {
 				rangeStart = i + 1
 			}
 		}

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -154,15 +154,53 @@ func (s MemoryStore) UpdateWorkflow(workflow resources.Workflow) error {
 	return nil
 }
 
-func (s MemoryStore) GetWorkflows(workflowName string) ([]resources.Workflow, error) {
+func (s MemoryStore) GetWorkflows(
+	query *store.WorkflowQuery,
+) ([]resources.Workflow, string, error) {
 	workflows := []resources.Workflow{}
 	for _, workflow := range s.workflows {
-		if workflow.WorkflowDefinition.Name() == workflowName {
+		if s.matchesQuery(workflow, query) {
 			workflows = append(workflows, workflow)
 		}
 	}
-	sort.Sort(sort.Reverse(ByCreatedAt(workflows))) // reverse to get newest first
-	return workflows, nil
+
+	if query.OldestFirst {
+		sort.Sort(ByCreatedAt(workflows))
+	} else {
+		sort.Sort(sort.Reverse(ByCreatedAt(workflows)))
+	}
+
+	rangeStart := 0
+	if query.PageToken != "" {
+		for i, workflow := range workflows {
+			if workflow.ID == query.PageToken {
+				rangeStart = i + 1
+			}
+		}
+	}
+
+	rangeEnd := rangeStart + query.Limit
+	if rangeEnd > len(workflows) {
+		rangeEnd = len(workflows)
+	}
+	nextPageToken := ""
+	if rangeEnd < len(workflows) {
+		nextPageToken = workflows[rangeEnd-1].ID
+	}
+
+	return workflows[rangeStart:rangeEnd], nextPageToken, nil
+}
+
+func (s MemoryStore) matchesQuery(workflow resources.Workflow, query *store.WorkflowQuery) bool {
+	if workflow.WorkflowDefinition.Name() != query.DefinitionName {
+		return false
+	}
+
+	if query.Status != "" && string(workflow.Status) != query.Status {
+		return false
+	}
+
+	return true
 }
 
 func (s MemoryStore) GetWorkflowByID(id string) (resources.Workflow, error) {

--- a/store/store.go
+++ b/store/store.go
@@ -57,3 +57,21 @@ func NewConflict(name string) ConflictError {
 func NewNotFound(name string) models.NotFound {
 	return models.NotFound{Message: name}
 }
+
+// InvalidPageTokenError is returned for workflow queries that contain a malformed or invalid page
+// token.
+type InvalidPageTokenError struct {
+	cause error
+}
+
+// NewInvalidPageTokenError returns a new InvalidPageTokenError.
+func NewInvalidPageTokenError(cause error) InvalidPageTokenError {
+	return InvalidPageTokenError{
+		cause: cause,
+	}
+}
+
+// Error implements the error interface.
+func (e InvalidPageTokenError) Error() string {
+	return fmt.Sprintf("invalid page token: %v", e.cause)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Clever/workflow-manager/resources"
 )
 
-// Store defines the interface for persistence of Workflow definitions.
+// Store defines the interface for persistence of Workflow Manager resources.
 type Store interface {
 	SaveWorkflowDefinition(def resources.WorkflowDefinition) error
 	UpdateWorkflowDefinition(def resources.WorkflowDefinition) (resources.WorkflowDefinition, error)

--- a/store/store.go
+++ b/store/store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Clever/workflow-manager/resources"
 )
 
-// WorkflowStore defines the interface for persistence of Workflow defintions
+// Store defines the interface for persistence of Workflow definitions.
 type Store interface {
 	SaveWorkflowDefinition(def resources.WorkflowDefinition) error
 	UpdateWorkflowDefinition(def resources.WorkflowDefinition) (resources.WorkflowDefinition, error)
@@ -24,10 +24,19 @@ type Store interface {
 	SaveWorkflow(workflow resources.Workflow) error
 	UpdateWorkflow(workflow resources.Workflow) error
 	GetWorkflowByID(id string) (resources.Workflow, error)
-	GetWorkflows(workflowName string) ([]resources.Workflow, error)
+	GetWorkflows(query *WorkflowQuery) ([]resources.Workflow, string, error)
 	GetPendingWorkflowIDs() ([]string, error)
 	LockWorkflow(id string) error
 	UnlockWorkflow(id string) error
+}
+
+// WorkflowQuery contains filtering options for workflow queries.
+type WorkflowQuery struct {
+	DefinitionName string
+	Limit          int
+	OldestFirst    bool
+	PageToken      string
+	Status         string
 }
 
 // ErrWorkflowLocked is returned from LockWorfklow in the case of the workflow already being locked.

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
@@ -307,6 +309,14 @@ func GetWorkflowsPagination(s store.Store, t *testing.T) func(t *testing.T) {
 		require.Len(t, workflows, 2)
 		require.Equal(t, workflow1.ID, workflows[0].ID)
 		require.Equal(t, workflow3.ID, workflows[1].ID)
+
+		// Verify handling for invalid page tokens.
+		query.PageToken = "invalid token"
+		workflows, nextPageToken, err := s.GetWorkflows(&query)
+		assert.Error(t, err)
+		assert.IsType(t, store.InvalidPageTokenError{}, err)
+		assert.Equal(t, "", nextPageToken)
+		assert.Len(t, workflows, 0)
 	}
 }
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -152,6 +152,10 @@ paths:
       parameters:
         # TODO: Add date range filters.
         - name: limit
+          description:
+            Maximum number of workflows to return.
+            Defaults to 10.
+            Restricted to a max of 10,000.
           in: query
           type: integer
           format: int32


### PR DESCRIPTION
Adds support for sorting/filtering/pagination to the `getWorkflows` API.
Uses a new secondary index on the concatenated workflow definition name and status: https://github.com/Clever/infra/pull/641

- [N/A] Update swagger.yml version
- [x] Run "make generate"
- [N/A] After merging, add a github tag to your merge commit
