### PR TITLE
tweak naming of state machines / resources

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -55,7 +55,7 @@ func wdRetryToSLRetry(wdRetry []*models.Retrier) []*models.SLRetrier {
 }
 
 func wdResourceToSLResource(wdResource, region, accountID, namespace string) string {
-	return fmt.Sprintf("arn:aws:states:%s:%s:activity:%s-%s", region, accountID, namespace, wdResource)
+	return fmt.Sprintf("arn:aws:states:%s:%s:activity:%s--%s", region, accountID, namespace, wdResource)
 }
 
 func wdToStateMachine(wd resources.WorkflowDefinition, region, accountID, namespace string) *models.SLStateMachine {
@@ -80,7 +80,7 @@ func wdToStateMachine(wd resources.WorkflowDefinition, region, accountID, namesp
 }
 
 func stateMachineName(wdName string, wdVersion int, namespace string, queue string) string {
-	return fmt.Sprintf("%s-%s-%d-%s", namespace, wdName, wdVersion, queue)
+	return fmt.Sprintf("%s--%s--%d--%s", namespace, wdName, wdVersion, queue)
 }
 
 func stateMachineARN(region, accountID, wdName string, wdVersion int, namespace string, queue string) string {

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -1,7 +1,46 @@
 package executor
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestSFNUpdateWorkflowStatus(t *testing.T) {
 	t.Log("TODO")
+}
+
+type stateMachineNameInput struct {
+	wdName    string
+	wdVersion int
+	namespace string
+	queue     string
+}
+
+type stateMachineNameTest struct {
+	input  stateMachineNameInput
+	output string
+}
+
+func TestStateMachineName(t *testing.T) {
+	tests := []stateMachineNameTest{
+		{
+			input: stateMachineNameInput{
+				wdName:    "cil-reliability-dashboard",
+				wdVersion: 3,
+				namespace: "production",
+				queue:     "default",
+			},
+			output: "production--cil-reliability-dashboard--3--default",
+		},
+	}
+	for _, test := range tests {
+		output := stateMachineName(
+			test.input.wdName,
+			test.input.wdVersion,
+			test.input.namespace,
+			test.input.queue,
+		)
+		require.Equal(t, output, test.output, "input: %#v", test.input)
+	}
 }


### PR DESCRIPTION
Use double dash `--` to separate the different components of state machine names and resource names