### PR TITLE
Workflow-id is now added to the jobs before they're submitted

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -130,7 +130,7 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition, input
 	if err := json.Unmarshal([]byte(input), &inputJSON); err != nil {
 		return nil, fmt.Errorf("input is not a valid JSON object: %s", err)
 	}
-	inputJSON["_EXECUTION_NAME"] = &executionName
+	inputJSON["_EXECUTION_NAME"] = *executionName
 
 	marshaledInput, err := json.Marshal(inputJSON)
 	if err != nil {

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -125,25 +125,24 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition, input
 	workflow := resources.NewWorkflow(&wd, input, namespace, queue, tags)
 
 	executionName := aws.String(workflow.ID)
+
+	var inputJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(input), &inputJSON); err != nil {
+		return nil, fmt.Errorf("input is not a valid JSON object: %s", err)
+	}
+	inputJSON["_EXECUTION_NAME"] = &executionName
+
+	marshaledInput, err := json.Marshal(inputJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	// We ensure the input is a json object, but for context the
 	// observed StartExecution behavior for different edge-case inputs:
 	// - nil: AWS converts this to an input of an empty object "{}"
 	// - aws.String(""): leads to InvalidExecutionInput AWS error
 	// - aws.String("[]"): leads to an input of an empty array "[]"
-	var startExecutionInput *string
-	if len(input) > 0 {
-		var inputJSON map[string]interface{}
-		if err := json.Unmarshal([]byte(input), &inputJSON); err != nil {
-			return nil, fmt.Errorf("input is not a valid JSON object: %s", err)
-		}
-		inputJSON["_EXECUTION_NAME"] = &executionName
-
-		marshaledInput, err := json.Marshal(inputJSON)
-		if err != nil {
-			return nil, err
-		}
-
-		startExecutionInput = aws.String(string(marshaledInput))
-	}
+	startExecutionInput := aws.String(string(marshaledInput))
 	_, err = wm.sfnapi.StartExecution(&sfn.StartExecutionInput{
 		StateMachineArn: describeOutput.StateMachineArn,
 		Input:           startExecutionInput,

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -135,7 +135,7 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition, input
 		if err := json.Unmarshal([]byte(input), &inputJSON); err != nil {
 			return nil, fmt.Errorf("input is not a valid JSON object: %s", err)
 		}
-		inputJSON["$execution-name"] = &executionName
+		inputJSON["_EXECUTION_NAME"] = &executionName
 
 		marshaledInput, err := json.Marshal(inputJSON)
 		if err != nil {

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -129,11 +129,18 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition, input
 	// - aws.String("[]"): leads to an input of an empty array "[]"
 	var startExecutionInput *string
 	if len(input) > 0 {
-		var inputJSON interface{}
+		var inputJSON map[string]interface{}
 		if err := json.Unmarshal([]byte(input), &inputJSON); err != nil {
-			return nil, fmt.Errorf("input is not valid JSON: %s", err)
+			return nil, fmt.Errorf("input is not a valid JSON object: %s", err)
 		}
-		startExecutionInput = aws.String(input)
+		inputJSON["$execution-name"] = workflow.ID
+
+		marshaledInput, err := json.Marshal(inputJSON)
+		if err != nil {
+			return nil, err
+		}
+
+		startExecutionInput = aws.String(string(marshaledInput))
 	}
 	_, err = wm.sfnapi.StartExecution(&sfn.StartExecutionInput{
 		StateMachineArn: describeOutput.StateMachineArn,


### PR DESCRIPTION
Workflow-id is now added as property as `$execution-name`.  It's used by sfncli and kayvee to make it easier to correlate logs from a workflow across many workers.

Also added validation to ensure that the worker input is a json object.

Related: https://github.com/Clever/sfncli/pull/4
Jira: https://clever.atlassian.net/browse/INFRA-2553, https://clever.atlassian.net/browse/INFRA-2526