### PR TITLE
use req.Manager in create/update WorkflowDefinition

### DIFF
--- a/executor/workflow_manager_batch_test.go
+++ b/executor/workflow_manager_batch_test.go
@@ -152,7 +152,7 @@ func TestUpdateWorkflowStatus(t *testing.T) {
 			},
 		},
 	}
-	wf, err = resources.NewWorkflowDefinition("test-worfklow", stateMachine)
+	wf, err = resources.NewWorkflowDefinition("test-worfklow", models.ManagerBatch, stateMachine)
 	workflow, err = jm.CreateWorkflow(*wf, input, "", "", tags)
 	assert.Nil(t, err)
 

--- a/handler.go
+++ b/handler.go
@@ -262,7 +262,7 @@ func newWorkflowDefinitionFromRequest(req models.NewWorkflowDefinitionRequest) (
 	if _, ok := req.StateMachine.States[req.StateMachine.StartAt]; !ok {
 		return nil, fmt.Errorf("StartAt state %s not defined", req.StateMachine.StartAt)
 	}
-	return resources.NewWorkflowDefinition(req.Name, req.StateMachine)
+	return resources.NewWorkflowDefinition(req.Name, req.Manager, req.StateMachine)
 }
 
 func validateTagsMap(apiTags map[string]interface{}) error {

--- a/handler_test.go
+++ b/handler_test.go
@@ -10,7 +10,8 @@ import (
 // TestNewWorkflowDefinitionFromRequest tests the newWorkflowFromRequest helper
 func TestNewWorkflowDefinitionFromRequest(t *testing.T) {
 	workflowReq := models.NewWorkflowDefinitionRequest{
-		Name: "test-workflow",
+		Name:    "test-workflow",
+		Manager: models.ManagerBatch,
 		StateMachine: &models.SLStateMachine{
 			StartAt: "start-state",
 			States: map[string]models.SLState{

--- a/resources/kitchensink.go
+++ b/resources/kitchensink.go
@@ -14,6 +14,7 @@ import (
 func KitchenSinkWorkflowDefinition(t *testing.T) *models.WorkflowDefinition {
 
 	wfd, err := NewWorkflowDefinition(fmt.Sprintf("kitchensink-%s", time.Now().Format(time.RFC3339Nano)),
+		models.ManagerStepFunctions,
 		&models.SLStateMachine{
 			Comment: "description",
 			StartAt: "start-state",

--- a/resources/workflow_definitions.go
+++ b/resources/workflow_definitions.go
@@ -11,13 +11,13 @@ import (
 )
 
 // NewWorkflowDefinition creates a new Workflow
-func NewWorkflowDefinition(name string, stateMachine *models.SLStateMachine) (*models.WorkflowDefinition, error) {
+func NewWorkflowDefinition(name string, manager models.Manager, stateMachine *models.SLStateMachine) (*models.WorkflowDefinition, error) {
 	return &models.WorkflowDefinition{
 		ID:           uuid.NewV4().String(),
 		Name:         name,
 		Version:      0,
 		CreatedAt:    strfmt.DateTime(time.Now()),
-		Manager:      models.ManagerStepFunctions,
+		Manager:      manager,
 		StateMachine: stateMachine,
 	}, nil
 }


### PR DESCRIPTION
No external API changes. Seems like this just slipped past the mega-schema migration.

- [ ] Update swagger.yml version
- [ ] Run "make generate"
- [ ] After merging, add a github tag to your merge commit
