### PR TITLE
Fix job input propagation for sfn manager.

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -220,7 +220,9 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 			case sfn.HistoryEventTypeTaskStateEntered:
 				stateEntered := evt.StateEnteredEventDetails
 				var input string
-				json.Unmarshal([]byte(*stateEntered.Input), &input)
+				if stateEntered.Input != nil {
+					input = *stateEntered.Input
+				}
 				state, ok := workflow.WorkflowDefinition.StateMachine.States[*stateEntered.Name]
 				var stateResourceName string
 				if ok {


### PR DESCRIPTION
Since the API exposes the input as a JSON string, skip the unmarshalling step and pass the input through directly.

Was previously generating empty strings.

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
- [N/A] After merging, add a github tag to your merge commit
