### PR TITLE
Handle ExecutionAborted and mark jobs as aborted_by_user accordingly.

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -264,6 +264,10 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 				if currentState != nil {
 					stateToJob[*currentState].Status = models.JobStatusSucceeded
 				}
+			case sfn.HistoryEventTypeExecutionAborted:
+				if currentState != nil {
+					stateToJob[*currentState].Status = models.JobStatusAbortedByUser
+				}
 			case sfn.HistoryEventTypeTaskStateExited:
 				stateExited := evt.StateExitedEventDetails
 				stateToJob[*stateExited.Name].StoppedAt = strfmt.DateTime(*evt.Timestamp)


### PR DESCRIPTION
When an `ExecutionAborted` event is encountered, mark the job as `aborted_by_user` (i.e. cancelled).

e.g. https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:mp-sfn--multiverse-multiverse-workflow-definition--1--development:3ee31208-f05a-45da-a537-78f403d66359

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
- [N/A] After merging, add a github tag to your merge commit
