### PR TITLE
fix ordering error in OrderedStates

### DIFF
--- a/resources/workflow_definitions.go
+++ b/resources/workflow_definitions.go
@@ -40,15 +40,18 @@ type StateAndDeps struct {
 }
 
 func OrderedStates(states map[string]models.SLState) ([]StateAndDeps, error) {
-	var stateDeps = map[string][]string{}
+	var stateDeps = make(map[string][]string)
 	for stateName, state := range states {
-		stateDeps[stateName] = []string{}
+		if _, ok := stateDeps[stateName]; !ok {
+			stateDeps[stateName] = []string{}
+		}
 
 		if !state.End {
 			if _, ok := states[state.Next]; !ok {
 				return nil, fmt.Errorf("%s.Next=%s, but %s not defined",
 					stateName, state.Next, state.Next)
 			}
+
 			if _, ok := stateDeps[state.Next]; !ok {
 				stateDeps[state.Next] = []string{stateName}
 			} else {

--- a/resources/workflow_definitions_test.go
+++ b/resources/workflow_definitions_test.go
@@ -1,0 +1,18 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedStates(t *testing.T) {
+
+	for i := 0; i < 10; i++ {
+		wf := KitchenSinkWorkflowDefinition(t)
+		orderedStates, err := OrderedStates(wf.StateMachine.States)
+		assert.Nil(t, err)
+		assert.Equal(t, "start-state", orderedStates[0].StateName)
+	}
+
+}


### PR DESCRIPTION
Found a bug in the task ordering logic for AWS Batch. Added a simple test to ensure that basic linear things are ordered. 