### PR TITLE
a little more resources

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -12,9 +12,9 @@ env:
   - AWS_SFN_ROLE_ARN
   - AWS_SFN_ACCOUNT_ID
 resources:
-  cpu: 0.1
-  soft_mem_limit: 0.05
-  max_mem: 0.1
+  cpu: 0.4
+  soft_mem_limit: 0.1
+  max_mem: 0.3
 autoscaling:
   metric: cpu
   metric_target: 65


### PR DESCRIPTION
While running load tests we've been seeing spikes in CPU and memory way above the currently requested resources. This will ensure that we have a better sense of where we land. 
