### PR TITLE
detect if activity doesn't exist

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -386,7 +386,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 					job := stateToJob[*currentState]
 					job.Status = models.JobStatusAbortedByUser
 					job.StoppedAt = strfmt.DateTime(*evt.Timestamp)
-
 					if details := evt.ExecutionAbortedEventDetails; details != nil {
 						job.StatusReason = aws.StringValue(details.Cause)
 					}
@@ -398,6 +397,13 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 					stateToJob[*stateExited.Name].Output = *stateExited.Output
 				}
 				currentState = nil
+			case sfn.HistoryEventTypeExecutionFailed:
+				if currentState != nil && isActivityDoesntExistFailure(evt.ExecutionFailedEventDetails) {
+					job := stateToJob[*currentState]
+					job.Status = models.JobStatusFailed
+					job.StoppedAt = strfmt.DateTime(*evt.Timestamp)
+					job.StatusReason = "State resource does not exist"
+				}
 			}
 		}
 		return true
@@ -407,4 +413,12 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 	workflow.Jobs = jobs
 
 	return wm.store.UpdateWorkflow(*workflow)
+}
+
+// isActivityDoesntExistFailure checks if an execution failed because an activity doesn't exist.
+// This currently results in a cryptic AWS error, so the logic is probably over-broad: https://console.aws.amazon.com/support/home?region=us-west-2#/case/?displayId=4514731511&language=en
+// If SFN creates a more descriptive error event we should change this.
+func isActivityDoesntExistFailure(details *sfn.ExecutionFailedEventDetails) bool {
+	return *details.Error == "States.Runtime" &&
+		strings.Contains(*details.Cause, "Internal Error")
 }


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2557

Added tests, also tested manually by deleting the activity for `raf--cil-reliability-dashboard` and attempting to submit a workflow for it. Checked the status and it now looks like this:

```
$ ark wfbeta status -e raf -w 49b4f429-8f3c-4413-b1dd-21355e943386
workflow ID:			49b4f429-8f3c-4413-b1dd-21355e943386
workflow Status:		failed
workflow Input:		{}
WorkflowDefinition Name:		cil-reliability-dashboard:master
WorkflowDefinition Version:	4
workflow Namespace:		raf
workflow Queue:		development

TASK ID    STATE    ECS TASK ID    STATUS                  STATUS REASON
2          start                   failed                  State resource does not exist
```