### PR TITLE
capture job attempts and associate events with jobs via previous / current event IDs

### DIFF
--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -219,9 +219,10 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 
 var jobFailedEventTimestamp = jobCreatedEventTimestamp.Add(5 * time.Minute)
 var jobFailedEvent = &sfn.HistoryEvent{
-	Id:        aws.Int64(2),
-	Timestamp: aws.Time(jobFailedEventTimestamp),
-	Type:      aws.String(sfn.HistoryEventTypeActivityFailed),
+	Id:              aws.Int64(2),
+	PreviousEventId: aws.Int64(1),
+	Timestamp:       aws.Time(jobFailedEventTimestamp),
+	Type:            aws.String(sfn.HistoryEventTypeActivityFailed),
 	ActivityFailedEventDetails: &sfn.ActivityFailedEventDetails{
 		Cause: aws.String("line1\nline2\nline3\nline4\nline5\nline6\n\n"),
 	},
@@ -297,9 +298,10 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 			cb(&sfn.GetExecutionHistoryOutput{Events: []*sfn.HistoryEvent{
 				jobCreatedEvent,
 				&sfn.HistoryEvent{
-					Id:        aws.Int64(2),
-					Timestamp: aws.Time(jobFailedEventTimestamp),
-					Type:      aws.String(sfn.HistoryEventTypeExecutionFailed),
+					Id:              aws.Int64(2),
+					PreviousEventId: jobCreatedEvent.Id,
+					Timestamp:       aws.Time(jobFailedEventTimestamp),
+					Type:            aws.String(sfn.HistoryEventTypeExecutionFailed),
 					ExecutionFailedEventDetails: &sfn.ExecutionFailedEventDetails{
 						Cause: aws.String("Internal Error (49b863bd-3367-4035-a76d-bfb2e777ece3)"),
 						Error: aws.String("States.Runtime"),
@@ -320,15 +322,17 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 
 var jobSucceededEventTimestamp = jobCreatedEventTimestamp.Add(5 * time.Minute)
 var jobSucceededEvent = &sfn.HistoryEvent{
-	Id:        aws.Int64(3),
-	Timestamp: aws.Time(jobSucceededEventTimestamp),
-	Type:      aws.String(sfn.HistoryEventTypeActivitySucceeded),
+	Id:              aws.Int64(2),
+	PreviousEventId: aws.Int64(1),
+	Timestamp:       aws.Time(jobSucceededEventTimestamp),
+	Type:            aws.String(sfn.HistoryEventTypeActivitySucceeded),
 }
 var jobExitedEventTimestamp = jobSucceededEventTimestamp.Add(5 * time.Second)
 var jobExitedEvent = &sfn.HistoryEvent{
-	Id:        aws.Int64(4),
-	Timestamp: aws.Time(jobExitedEventTimestamp),
-	Type:      aws.String(sfn.HistoryEventTypeTaskStateExited),
+	Id:              aws.Int64(3),
+	PreviousEventId: aws.Int64(2),
+	Timestamp:       aws.Time(jobExitedEventTimestamp),
+	Type:            aws.String(sfn.HistoryEventTypeTaskStateExited),
 	StateExitedEventDetails: &sfn.StateExitedEventDetails{
 		Name:   jobCreatedEvent.StateEnteredEventDetails.Name,
 		Output: aws.String(`{out: "put"}`),
@@ -382,9 +386,10 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 
 var jobAbortedEventTimestamp = jobSucceededEventTimestamp.Add(5 * time.Minute)
 var jobAbortedEvent = &sfn.HistoryEvent{
-	Id:        aws.Int64(5),
-	Timestamp: aws.Time(jobAbortedEventTimestamp),
-	Type:      aws.String(sfn.HistoryEventTypeExecutionAborted),
+	Id:              aws.Int64(5),
+	PreviousEventId: aws.Int64(1),
+	Timestamp:       aws.Time(jobAbortedEventTimestamp),
+	Type:            aws.String(sfn.HistoryEventTypeExecutionAborted),
 	ExecutionAbortedEventDetails: &sfn.ExecutionAbortedEventDetails{
 		Cause: aws.String("sfn abort reason"),
 	},


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2575
https://clever.atlassian.net/browse/INFRA-2547

here's an example execution that had a state retry once: https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:raf--cil-reliability-dashboard-master--4--start:3956fc73-d95a-43f6-9984-22f5e5f07ffd

before, workflow-manager would return an empty "attempts" array, only reporting the successful job run: 

```
curl https://clever-dev--workflow-manager.int.clever.com/workflows/3956fc73-d95a-43f6-9984-22f5e5f07ffd
{
	"createdAt": "2017-10-09T22:31:02.497Z",
	"id": "3956fc73-d95a-43f6-9984-22f5e5f07ffd",
	"input": "{}",
	"jobs": [
		{
			"attempts": null,
			"createdAt": "2017-10-09T22:31:02.000Z",
			"id": "2",
			"input": "{\"_EXECUTION_NAME\":\"3956fc73-d95a-43f6-9984-22f5e5f07ffd\"}",
			"output": "{\"_EXECUTION_NAME\":\"3956fc73-d95a-43f6-9984-22f5e5f07ffd\",\"done\":true}",
			"startedAt": "2017-10-09T22:31:02.000Z",
			"state": "start",
			"stateResource": {
				"lastUpdated": "2017-10-09T22:31:02.000Z",
				"name": "cil-reliability-dashboard",
				"namespace": "raf",
				"type": "ActivityARN"
			},
			"status": "succeeded",
			"stoppedAt": "2017-10-09T22:33:13.000Z"
		}
	],
	"lastUpdated": "2017-10-09T22:38:00.122Z",
	"namespace": "raf",
	"queue": "development",
	"retries": null,
	"status": "succeeded",
	"workflowDefinition": {
		"createdAt": "2017-10-02T22:20:48.497Z",
		"id": "872ea0df-0a09-4118-868d-bc2324af8078",
		"manager": "step-functions",
		"name": "cil-reliability-dashboard:master",
		"stateMachine": {
			"StartAt": "start",
			"States": {
				"start": {
					"End": true,
					"Resource": "cil-reliability-dashboard",
					"Retry": null,
					"Type": "Task"
				}
			},
			"Version": "1.0"
		},
		"version": 4
	}
}
```

Now it fills in the attempts array:

```
$ curl localhost:8080/workflows/3956fc73-d95a-43f6-9984-22f5e5f07ffd
{
	"createdAt": "2017-10-09T22:31:02.497Z",
	"id": "3956fc73-d95a-43f6-9984-22f5e5f07ffd",
	"input": "{}",
	"jobs": [
		{
			"attempts": [
				{
					"reason": "sfncli.CommandTerminated",
					"startedAt": "2017-10-09T22:31:02.000Z",
					"stoppedAt": "2017-10-09T22:31:20.000Z",
					"taskARN": "ubuntu-xenial"
				}
			],
			"container": "ubuntu-xenial",
			"createdAt": "2017-10-09T22:31:30.000Z",
			"id": "6",
			"input": "{\"_EXECUTION_NAME\":\"3956fc73-d95a-43f6-9984-22f5e5f07ffd\"}",
			"output": "{\"_EXECUTION_NAME\":\"3956fc73-d95a-43f6-9984-22f5e5f07ffd\",\"done\":true}",
			"startedAt": "2017-10-09T22:31:30.000Z",
			"state": "start",
			"stateResource": {
				"lastUpdated": "2017-10-09T22:31:30.000Z",
				"name": "cil-reliability-dashboard",
				"namespace": "raf",
				"type": "ActivityARN"
			},
			"status": "succeeded",
			"stoppedAt": "2017-10-09T22:33:13.000Z"
		}
	],
	"lastUpdated": "2017-10-10T23:13:35.200Z",
	"namespace": "raf",
	"queue": "development",
	"retries": null,
	"status": "succeeded",
	"workflowDefinition": {
		"createdAt": "2017-10-02T22:20:48.497Z",
		"id": "872ea0df-0a09-4118-868d-bc2324af8078",
		"manager": "step-functions",
		"name": "cil-reliability-dashboard:master",
		"stateMachine": {
			"StartAt": "start",
			"States": {
				"start": {
					"End": true,
					"Resource": "cil-reliability-dashboard",
					"Retry": null,
					"Type": "Task"
				}
			},
			"Version": "1.0"
		},
		"version": 4
	}
}
```