### PR TITLE
cache DescribeStateMachine calls

### DIFF
--- a/executor/sfncache/sfn.go
+++ b/executor/sfncache/sfn.go
@@ -1,0 +1,39 @@
+package sfncache
+
+import (
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+type sfnCache struct {
+	sfniface.SFNAPI
+	describeStateMachineCache *lru.Cache
+}
+
+// New creates a new cached version of SFNAPI.
+func New(sfnapi sfniface.SFNAPI) (sfniface.SFNAPI, error) {
+	describeStateMachineCache, err := lru.New(1000)
+	if err != nil {
+		return nil, err
+	}
+	return &sfnCache{
+		SFNAPI: sfnapi,
+		describeStateMachineCache: describeStateMachineCache,
+	}, nil
+}
+
+// DescribeStateMachine is cached aggressively since state machines are immutable.
+func (s *sfnCache) DescribeStateMachine(i *sfn.DescribeStateMachineInput) (*sfn.DescribeStateMachineOutput, error) {
+	cacheKey := i.String()
+	cacheVal, ok := s.describeStateMachineCache.Get(cacheKey)
+	if ok {
+		return cacheVal.(*sfn.DescribeStateMachineOutput), nil
+	}
+	out, err := s.SFNAPI.DescribeStateMachine(i)
+	if err != nil {
+		return out, err
+	}
+	s.describeStateMachineCache.Add(cacheKey, out)
+	return out, nil
+}

--- a/executor/sfncache/sfn_test.go
+++ b/executor/sfncache/sfn_test.go
@@ -1,0 +1,28 @@
+package sfncache
+
+import (
+	"testing"
+
+	"github.com/Clever/workflow-manager/mocks/mock_sfniface"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeStateMachineCache(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	expectedOutput := &sfn.DescribeStateMachineOutput{}
+	mockSFNAPI := mock_sfniface.NewMockSFNAPI(mockController)
+	mockSFNAPI.EXPECT().
+		DescribeStateMachine(gomock.Any()).
+		Return(expectedOutput, nil).
+		Times(1)
+	cachedSFN, err := New(mockSFNAPI)
+	require.Nil(t, err)
+	for i := 0; i < 1000; i++ {
+		output, err := cachedSFN.DescribeStateMachine(&sfn.DescribeStateMachineInput{})
+		require.Nil(t, err)
+		require.Equal(t, expectedOutput, output)
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5373297ef32b83a97a2201e21d3d721baecab54227c2a3ce2ee4d63c23b14027
-updated: 2017-10-08T00:25:26.477298241Z
+hash: 3320bb64171fe5ce66dcee92d76028c7d3c45a2e586736950af6f824d60fce68
+updated: 2017-10-12T18:55:36.303555411Z
 imports:
 - name: github.com/afex/hystrix-go
   version: f118cd938f786d24f46cc307981d8f63b7951020
@@ -10,7 +10,7 @@ imports:
 - name: github.com/asaskevich/govalidator
   version: eb06e9c4d8e04c43e16e5241db85df221ec5c17f
 - name: github.com/aws/aws-sdk-go
-  version: 760741802ad40f49ae9fc4a69ef6706d2527d62e
+  version: 64850c09d35fc1dc005ca76c13fed9382e34e7e3
   subpackages:
   - aws
   - aws/awserr
@@ -57,6 +57,8 @@ imports:
   - spew
 - name: github.com/donovanhide/eventsource
   version: b8f31a59085e69dd2678cf51840db2ac625cb741
+- name: github.com/ghodss/yaml
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
@@ -101,6 +103,8 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/hashicorp/golang-lru
+  version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/kardianos/osext
@@ -200,7 +204,7 @@ imports:
   - tap
   - transport
 - name: gopkg.in/Clever/kayvee-go.v6
-  version: e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5
+  version: e1e6fd8184162847c1123645e7058347a2fd3959
   subpackages:
   - logger
   - middleware

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,7 +20,7 @@ import:
   subpackages:
   - assert
 - package: github.com/kardianos/osext
-- package: gopkg.in/Clever/kayvee-go
+- package: gopkg.in/Clever/kayvee-go.v6
   version: ^6.10.0
 - package: github.com/golang/mock
   version: master
@@ -30,3 +30,4 @@ import:
   version: 83dd4ef
   repo: git@github.com:Clever/ddbsync.git
 - package: github.com/mohae/deepcopy
+- package: github.com/hashicorp/golang-lru


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2580

AWS rate limits DescribeStateMachine with a token bucket that refills at a rate of 1 per second. We will hit this pretty quickly under normal use.

This PR caches calls to that API method using an LRU cache w/ space for 1000 state machines. State machines are immutable and not that big, so caching this method doesn't present a huge risk.