### PR TITLE
generate VERSION for github-release on make generate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,2 @@
 - [ ] Update swagger.yml version
 - [ ] Run "make generate"
-- [ ] After merging, add a github tag to your merge commit

--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,8 @@ deployment:
       - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME dev-infra confirm-then-deploy
       - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy
       - $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN gen-js/
+      # create a VERSION file to push a github release
+      - cat ./swagger.yml | grep "^  version:" | cut -d":" -f2 | tr -d " " > ./VERSION
+      - $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN
 general:
   build_dir: ../.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,9 +4,7 @@ info:
   description: Minimal Workflow orchestrator for AWS Batch
   # when changing the version here, make sure to
   # 1. re-run `make generate` to generate clients and server
-  # 2. merge the new clients, and, after merging, tag the commit with the version:
-  #    git tag -a vX.Y.Z -m "vX.Y.Z"
-  #    git push origin --tags
+  # 2. merge the new clients
   version: 0.6.3
   x-npm-package: workflow-manager
 schemes:


### PR DESCRIPTION
Everytime `make generate` is run the `VERSION` file is updated with the swagger client version which can then be used by the `github-release` script to automatically tag the release. 


- [NA] Update swagger.yml version
- [ * ] Run "make generate"
