### PR TITLE
Fix job update logic for execution-level events

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -369,6 +369,12 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 			jobs = append(jobs, job)
 			eventIDToJob[eventID] = job
 			return job
+		case sfn.HistoryEventTypeExecutionAborted:
+			// Execution-level event - update last seen job.
+			return jobs[len(jobs)-1]
+		case sfn.HistoryEventTypeExecutionFailed:
+			// Execution-level event - update last seen job.
+			return jobs[len(jobs)-1]
 		default:
 			// associate this event with the same job as its parent event
 			job, ok := eventIDToJob[parentEventID]
@@ -390,12 +396,11 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 		// 3) stop paging once we get to to the smallest job ID (aka event ID) that is still pending
 		for _, evt := range historyOutput.Events {
 			job := eventToJob(evt)
+			if job == nil {
+				continue
+			}
 			switch aws.StringValue(evt.Type) {
 			case sfn.HistoryEventTypeTaskStateEntered:
-				if job == nil {
-					continue
-				}
-
 				// event IDs start at 1 and are only unique to the execution, so this might not be ideal
 				job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
 				job.Attempts = []*models.JobAttempt{}
@@ -419,10 +424,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 					}
 				}
 			case sfn.HistoryEventTypeActivityScheduled:
-				if job == nil {
-					continue
-				}
-
 				if job.Status == models.JobStatusFailed {
 					// this is a retry, copy job data to attempt array, re-initialize job data
 					oldJobData := *job
@@ -447,19 +448,11 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 				}
 				job.Status = models.JobStatusQueued
 			case sfn.HistoryEventTypeActivityStarted:
-				if job == nil {
-					continue
-				}
-
 				job.Status = models.JobStatusRunning
 				if details := evt.ActivityStartedEventDetails; details != nil {
 					job.Container = aws.StringValue(details.WorkerName)
 				}
 			case sfn.HistoryEventTypeActivityFailed:
-				if job == nil {
-					continue
-				}
-
 				job.Status = models.JobStatusFailed
 				job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				if details := evt.ActivityFailedEventDetails; details != nil {
@@ -471,26 +464,14 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 					))
 				}
 			case sfn.HistoryEventTypeActivitySucceeded:
-				if job != nil {
-					job.Status = models.JobStatusSucceeded
-				}
+				job.Status = models.JobStatusSucceeded
 			case sfn.HistoryEventTypeExecutionAborted:
-				if job == nil {
-					// Execution-level event - update last seen job.
-					job = jobs[len(jobs)-1]
-				}
-
 				job.Status = models.JobStatusAbortedByUser
 				job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				if details := evt.ExecutionAbortedEventDetails; details != nil {
 					job.StatusReason = aws.StringValue(details.Cause)
 				}
 			case sfn.HistoryEventTypeExecutionFailed:
-				if job == nil {
-					// Execution-level event - update last seen job.
-					job = jobs[len(jobs)-1]
-				}
-
 				job.Status = models.JobStatusFailed
 				job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				if details := evt.ExecutionFailedEventDetails; details != nil {
@@ -506,10 +487,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 					}
 				}
 			case sfn.HistoryEventTypeTaskStateExited:
-				if job == nil {
-					continue
-				}
-
 				stateExited := evt.StateExitedEventDetails
 				job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				if stateExited.Output != nil {

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -298,10 +298,9 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 			cb(&sfn.GetExecutionHistoryOutput{Events: []*sfn.HistoryEvent{
 				jobCreatedEvent,
 				&sfn.HistoryEvent{
-					Id:              aws.Int64(2),
-					PreviousEventId: jobCreatedEvent.Id,
-					Timestamp:       aws.Time(jobFailedEventTimestamp),
-					Type:            aws.String(sfn.HistoryEventTypeExecutionFailed),
+					Id:        aws.Int64(2),
+					Timestamp: aws.Time(jobFailedEventTimestamp),
+					Type:      aws.String(sfn.HistoryEventTypeExecutionFailed),
 					ExecutionFailedEventDetails: &sfn.ExecutionFailedEventDetails{
 						Cause: aws.String("Internal Error (49b863bd-3367-4035-a76d-bfb2e777ece3)"),
 						Error: aws.String("States.Runtime"),
@@ -386,10 +385,9 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 
 var jobAbortedEventTimestamp = jobSucceededEventTimestamp.Add(5 * time.Minute)
 var jobAbortedEvent = &sfn.HistoryEvent{
-	Id:              aws.Int64(5),
-	PreviousEventId: aws.Int64(1),
-	Timestamp:       aws.Time(jobAbortedEventTimestamp),
-	Type:            aws.String(sfn.HistoryEventTypeExecutionAborted),
+	Id:        aws.Int64(5),
+	Timestamp: aws.Time(jobAbortedEventTimestamp),
+	Type:      aws.String(sfn.HistoryEventTypeExecutionAborted),
 	ExecutionAbortedEventDetails: &sfn.ExecutionAbortedEventDetails{
 		Cause: aws.String("sfn abort reason"),
 	},


### PR DESCRIPTION
Make sure we update the last-seen job when we encounter an execution event (which wouldn't have a `PreviousEventId` value).

**Testing:**
- Confirmed that this properly sets the status and status reason on the last job if the execution fails. e.g. [hubble/87dc43fd-fc1b-4ccb-bdf5-acb8cc4b106c](https://clever-dev--hubble.int.clever.com/multiverse:master/workflows/w/87dc43fd-fc1b-4ccb-bdf5-acb8cc4b106c/jobs)
- (Compare with [hubble/28c60677-3da2-4199-bb6a-85e198c67ab4](https://clever-dev--hubble.int.clever.com/multiverse:master/workflows/apps/5674595f800a410001000004/w/28c60677-3da2-4199-bb6a-85e198c67ab4/jobs))

**Rollout:**
- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
