### PR TITLE
On ExecutionNotFound wait 5 minutes before failing

### DIFF
--- a/executor/log_helpers_test.go
+++ b/executor/log_helpers_test.go
@@ -42,9 +42,7 @@ func TestDataResultsRouting(t *testing.T) {
 		}},
 		models.WorkflowStatusRunning)
 	counts = mocklog.RuleCounts()
-	assert.Equal(3, len(counts))
-	assert.Contains(counts, "workflow-status-metrics")
-	assert.Equal(counts["workflow-status-metrics"], 1)
+	assert.Equal(2, len(counts))
 	assert.Contains(counts, "workflow-status-alerts")
 	assert.Equal(counts["workflow-status-alerts"], 1)
 }

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -1,15 +1,8 @@
+---
 routes:
 
-  # matchers for tracking Jobs/Workflows/Tasks; prefix with `workflows.`
-
-  workflow-status-metrics:
-    matchers:
-      title: ["workflow-status-change"]
-    output:
-      type: "metrics"
-      series: "workflows.workflow-status"
-      dimensions: ["id", "name", "version", "status"]
-  workflow-status-alerts:
+  # matchers for tracking Jobs/Workflows; prefix with `workflows.`
+  workflow-status-alerts:  # currently for batch only
     matchers:
       title: ["workflow-status-change"]
     output:
@@ -19,7 +12,7 @@ routes:
       # 0 for ongoing; 1 for failed; -1 for cancelled
       value_field: "value"
       stat_type: "gauge"
-  job-status-alerts:
+  job-status-alerts:  # currently for batch only
     matchers:
       title: ["job-status"]
     output:
@@ -34,9 +27,19 @@ routes:
   # workflow-manager related matchers; prefix with workflow-mananger
   workflow-polling-alerts:
     matchers:
-      title: ["workflow-polling-error"]
+      title: ["polling-for-pending-workflows"]
+      level: ["error"]
     output:
       type: "alerts"
       series: "workflow-manager.workflow-polling-error"
-      dimensions: ["id", "status", "name"]
+      dimensions: ["id"]
+      stat_type: "counter"
+
+  execution-not-found-alert:
+    matchers:
+      title: ["execution-not-found"]
+    output:
+      type: "alerts"
+      series: "workflow-manager.execution-not-found"
+      dimensions: ["workflow-id", "execution-id"]
       stat_type: "counter"


### PR DESCRIPTION
* Add workflow-id in logs for polling failures when possible
* send poll-for-pending-workflows errors to signalfx

* if lastUpdated < 5 minutes and we hit ExecutionNotFound, then don't
fail:
  | This delay would not work as intended if there is a large backlog in
  our update workflow polling, but in that case we should not have a
  consistency issue anyways.

NOTE: I'm not a 100% sure that the issue where we saw a
ExecutionNotFound error for an execution that later existed was due to a
quick status check. These changes should also allow us to setup alerts
so that if we see ExecutionNotFound errors we can investigate right
away.

- [ N/A ] Update swagger.yml version
- [ N/A ] Run "make generate"
