### PR TITLE
[Proposal] Start parsing details for Choice and Succeed tasks for client visibility

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -355,7 +355,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 	workflow.Output = aws.StringValue(describeOutput.Output) // use for error or success
 
 	// Pull in execution history to populate jobs array
-	// Each Job corresponds to a type="Task" state, i.e. a state with some Resource that will process the input to the state.
+	// Each Job corresponds to a type={Task,Choice,Succeed} state, i.e. States we have currently tested and supported completely
 	// We only create a Job object if the State has been entered.
 	// Execution history events contain a "previous" event ID which is the "parent" event within the execution tree.
 	// E.g., if a state machine has two parallel Task states, the events for these states will overlap in the history, but the event IDs + previous event IDs will link together the parallel execution paths.
@@ -373,10 +373,10 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 			sfn.HistoryEventTypeParallelStateEntered, sfn.HistoryEventTypeParallelStateExited,
 			sfn.HistoryEventTypeWaitStateEntered, sfn.HistoryEventTypeWaitStateExited,
 			sfn.HistoryEventTypeFailStateEntered:
-			// only Task states have jobs
+			// only create Jobs for Task, Choice and Succeed states
 			return nil
 		case sfn.HistoryEventTypeTaskStateEntered, sfn.HistoryEventTypeChoiceStateEntered, sfn.HistoryEventTypeSucceedStateEntered:
-			// a job is created when a task state is entered
+			// a job is created when a supported state is entered
 			job := &models.Job{}
 			jobs = append(jobs, job)
 			eventIDToJob[eventID] = job


### PR DESCRIPTION
Would like to include details about which branch of the workflow was taken, so that it's clearer to users (and the client doesn't have to extrapolate).

**Basically go from this (no job data past last Task):**
https://clever-dev--hubble.int.clever.com/multiverse:master/workflows/w/77e8b1f0-a2e7-4b28-8794-438ce8a0cb23/jobs
![Screenshot from Gyazo](https://gyazo.com/972dea84033fc5e41aec624002bd9333/raw)

**to this (Choice and Succeed step details included):**
https://clever-dev--hubble.int.clever.com/multiverse:master/workflows/w/1ec091c2-3e88-4087-8ffa-e4f9c47c6851/jobs
![Screenshot from Gyazo](https://gyazo.com/0d08a4403f6a0daa21f253b88a8cc600/raw)

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
