### PR TITLE
log / route count of calls to GetExecutionHistory

### DIFF
--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -46,3 +46,9 @@ func logPendingWorkflowsLocked(wf models.Workflow) {
 		"update-loop-lag-seconds": int(time.Now().Sub(time.Time(wf.LastUpdated)) / time.Second),
 	})
 }
+
+func LogGetExecutionHistoryCount(value int64) {
+	log.InfoD("get-execution-history-count", logger.M{
+		"value": value,
+	})
+}

--- a/executor/log_helpers_test.go
+++ b/executor/log_helpers_test.go
@@ -20,7 +20,6 @@ func init() {
 func TestRoutingRules(t *testing.T) {
 	t.Run("update-loop-lag-alert", func(t *testing.T) {
 		mocklog := logger.NewMockCountLogger("workflow-manager")
-		// Overrides package level logger
 		log = mocklog
 		logPendingWorkflowsLocked(models.Workflow{
 			WorkflowSummary: models.WorkflowSummary{
@@ -33,5 +32,15 @@ func TestRoutingRules(t *testing.T) {
 		assert.Equal(t, 1, len(counts))
 		assert.Contains(t, counts, "update-loop-lag-alert")
 		assert.Equal(t, counts["update-loop-lag-alert"], 1)
+	})
+
+	t.Run("get-execution-history-count", func(t *testing.T) {
+		mocklog := logger.NewMockCountLogger("workflow-manager")
+		log = mocklog
+		LogGetExecutionHistoryCount(100)
+		counts := mocklog.RuleCounts()
+		assert.Equal(t, 1, len(counts))
+		assert.Contains(t, counts, "get-execution-history-count")
+		assert.Equal(t, counts["get-execution-history-count"], 1)
 	})
 }

--- a/executor/sfncache/sfn.go
+++ b/executor/sfncache/sfn.go
@@ -6,7 +6,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
-type sfnCache struct {
+type SFNCache struct {
 	sfniface.SFNAPI
 	describeStateMachineCache *lru.Cache
 }
@@ -17,14 +17,14 @@ func New(sfnapi sfniface.SFNAPI) (sfniface.SFNAPI, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &sfnCache{
+	return &SFNCache{
 		SFNAPI: sfnapi,
 		describeStateMachineCache: describeStateMachineCache,
 	}, nil
 }
 
 // DescribeStateMachine is cached aggressively since state machines are immutable.
-func (s *sfnCache) DescribeStateMachine(i *sfn.DescribeStateMachineInput) (*sfn.DescribeStateMachineOutput, error) {
+func (s *SFNCache) DescribeStateMachine(i *sfn.DescribeStateMachineInput) (*sfn.DescribeStateMachineOutput, error) {
 	cacheKey := i.String()
 	cacheVal, ok := s.describeStateMachineCache.Get(cacheKey)
 	if ok {

--- a/executor/sfncounter/cumulativebucket.go
+++ b/executor/sfncounter/cumulativebucket.go
@@ -1,0 +1,97 @@
+// this file borrows from https://github.com/signalfx/golib
+package sfncounter
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+)
+
+type atomicFloat struct {
+	bits uint64
+}
+
+func (a *atomicFloat) Get() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&a.bits))
+}
+
+func (a *atomicFloat) Add(f float64) {
+	for {
+		oldValue := atomic.LoadUint64(&a.bits)
+		newValue := math.Float64bits(math.Float64frombits(oldValue) + f)
+		if atomic.CompareAndSwapUint64(&a.bits, oldValue, newValue) {
+			break
+		}
+	}
+}
+
+// Result is a cumulated result of items that can be added to a CumulativeBucket at once
+type Result struct {
+	Count        int64
+	Sum          int64
+	SumOfSquares float64
+}
+
+// Add a single number to the bucket.  This does not use atomic operations and is not thread safe,
+// but adding a finished Result into a CumulativeBucket is thread safe.
+func (r *Result) Add(val int64) {
+	r.Count++
+	r.Sum += val
+	// Sum of squares tends to roll over pretty easily
+	r.SumOfSquares += float64(val) * float64(val)
+}
+
+// A CumulativeBucket tracks groups of values, reporting the count/sum/sum of squares
+// as a cumulative counter.
+type CumulativeBucket struct {
+	MetricName string
+	Dimensions map[string]string
+
+	count        int64
+	sum          int64
+	sumOfSquares atomicFloat
+}
+
+//var _ Collector = &CumulativeBucket{}
+
+// Add an item to the bucket, later reporting the result in the next report cycle.
+func (b *CumulativeBucket) Add(val int64) {
+	r := &Result{}
+	r.Add(val)
+	b.MultiAdd(r)
+}
+
+// MultiAdd many items into the bucket at once using a Result.  This can be more efficient as it
+// involves only a constant number of atomic operations.
+func (b *CumulativeBucket) MultiAdd(res *Result) {
+	if res.Count == 0 {
+		return
+	}
+	atomic.AddInt64(&b.count, res.Count)
+	atomic.AddInt64(&b.sum, res.Sum)
+	b.sumOfSquares.Add(res.SumOfSquares)
+}
+
+// Datapoints returns the count/sum/sumsquare datapoints, or nil if there is no set metric name
+func (b *CumulativeBucket) Datapoints() []*datapoint.Datapoint {
+	if b.MetricName == "" {
+		return []*datapoint.Datapoint{}
+	}
+	return []*datapoint.Datapoint{
+		CumulativeP(b.MetricName+".count", b.Dimensions, &b.count),
+		CumulativeP(b.MetricName+".sum", b.Dimensions, &b.sum),
+		CumulativeF(b.MetricName+".sumsquare", b.Dimensions, b.sumOfSquares.Get()),
+	}
+}
+
+// CumulativeP creates a SignalFx cumulative counter for integer values from a pointer that is loaded atomically.
+func CumulativeP(metricName string, dimensions map[string]string, val *int64) *datapoint.Datapoint {
+	return datapoint.New(metricName, dimensions, datapoint.NewIntValue(atomic.LoadInt64(val)), datapoint.Counter, time.Time{})
+}
+
+// CumulativeF creates a SignalFx cumulative counter for float values.
+func CumulativeF(metricName string, dimensions map[string]string, val float64) *datapoint.Datapoint {
+	return datapoint.New(metricName, dimensions, datapoint.NewFloatValue(val), datapoint.Counter, time.Time{})
+}

--- a/executor/sfncounter/sfn.go
+++ b/executor/sfncounter/sfn.go
@@ -1,0 +1,55 @@
+package sfncounter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
+	"github.com/signalfx/golib/datapoint"
+)
+
+// SFNCounter periodically logs a cumulative counter for API calls made to SFN
+type SFNCounter struct {
+	sfniface.SFNAPI
+	getExecutionHistory *CumulativeBucket
+}
+
+// New creates a new SFNCounter
+func New(sfnapi sfniface.SFNAPI) *SFNCounter {
+	return &SFNCounter{
+		SFNAPI: sfnapi,
+		getExecutionHistory: &CumulativeBucket{
+			MetricName: "get-execution-history",
+			Dimensions: map[string]string{},
+		},
+	}
+}
+
+// countGetExecutionHistory counts GetExectuionHistory requests.
+// These requests are limited via a token bucket of size 250 with refill rate of 5/sec.
+// See http://docs.aws.amazon.com/step-functions/latest/dg/limits.html.
+func (s *SFNCounter) countGetExecutionHistoryRequest(*request.Request) {
+	s.getExecutionHistory.Add(1)
+}
+
+// GetExecutionHistoryPagesWithContext is counted by injecting a request option that increments the count.
+// This captures all underlying GetExectuionHistory HTTP requests.
+func (s *SFNCounter) GetExecutionHistoryPagesWithContext(ctx aws.Context, i *sfn.GetExecutionHistoryInput, fn func(*sfn.GetExecutionHistoryOutput, bool) bool, opts ...request.Option) error {
+	opts = append(opts, s.countGetExecutionHistoryRequest)
+	return s.SFNAPI.GetExecutionHistoryPagesWithContext(ctx, i, fn, opts...)
+}
+
+// GetExecutionHistoryCount returns the cumulative count of requests to GetExecutionHistory.
+func (s *SFNCounter) GetExecutionHistoryCount() datapoint.IntValue {
+	// cumulative bucket tracks count, sum, and sum squares.
+	// these are int, int, and float values, respectively
+	// since we're always adding 1 (`Add(1)` above) these datapoints all be the same.
+	// so just pick the first int we see
+	dps := s.getExecutionHistory.Datapoints()
+	for _, dp := range dps {
+		if iv, ok := dp.Value.(datapoint.IntValue); ok {
+			return iv
+		}
+	}
+	return nil
+}

--- a/executor/sfncounter/sfn_test.go
+++ b/executor/sfncounter/sfn_test.go
@@ -1,0 +1,27 @@
+package sfncounter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Clever/workflow-manager/mocks/mock_sfniface"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExecutionHistoryRequestCount(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	mockSFNAPI := mock_sfniface.NewMockSFNAPI(mockController)
+	countedSFN := New(mockSFNAPI)
+	// expect a request option to be added to the call to GetExecutionHistoryPagesWithContext
+	mockSFNAPI.EXPECT().
+		GetExecutionHistoryPagesWithContext(gomock.Eq(context.Background()), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(1)
+	err := countedSFN.GetExecutionHistoryPagesWithContext(context.Background(), &sfn.GetExecutionHistoryInput{}, func(*sfn.GetExecutionHistoryOutput, bool) bool {
+		return true
+	})
+	require.Nil(t, err)
+}

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -412,7 +413,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowStatus(workflow *models.Workflow) er
 			return job
 		}
 	}
-	if err := wm.sfnapi.GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+	if err := wm.sfnapi.GetExecutionHistoryPagesWithContext(context.TODO(), &sfn.GetExecutionHistoryInput{
 		ExecutionArn: aws.String(execARN),
 	}, func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool {
 		// NOTE: if pulling the entire execution history becomes infeasible, we can:

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -235,10 +235,11 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 			Status: aws.String(sfn.ExecutionStatusRunning),
 		}, nil)
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -281,10 +282,11 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -323,10 +325,11 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -399,10 +402,11 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -456,10 +460,11 @@ func TestUpdateWorkflowStatusJobCancelled(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -496,10 +501,11 @@ func TestUpdateWorkflowStatusWorkflowCancelledAfterJobSucceeded(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {
@@ -546,10 +552,11 @@ func TestUpdateWorkflowStatusExecutionNotFound(t *testing.T) {
 		}, nil)
 
 	c.mockSFNAPI.EXPECT().
-		GetExecutionHistoryPages(&sfn.GetExecutionHistoryInput{
+		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}, gomock.Any()).
 		Do(func(
+			ctx aws.Context,
 			input *sfn.GetExecutionHistoryInput,
 			cb func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool,
 		) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: eb4e626598943a05015cf3f07168a20aaf4a869f072ebebc7cdc28dc4d18f18b
-updated: 2017-10-18T20:01:41.160141602Z
+hash: 2225e3f62f575a40fad038725c96dec222f9ceacce04af358aa9d33694653e6b
+updated: 2017-10-26T16:20:25.574277975Z
 imports:
 - name: github.com/afex/hystrix-go
   version: f118cd938f786d24f46cc307981d8f63b7951020
@@ -8,9 +8,9 @@ imports:
   - hystrix/metric_collector
   - hystrix/rolling
 - name: github.com/asaskevich/govalidator
-  version: ca5f9e638c83bac66bfac70ded5bded1503135a7
+  version: ddb193b4c7bfa1d1c1923ae05a1ee8fb0cd45cf3
 - name: github.com/aws/aws-sdk-go
-  version: 044a61f1536640ce1def6088c0914f5905990202
+  version: f426770fd5a4bae6186b280d4af7dca83a4cdef4
   subpackages:
   - aws
   - aws/awserr
@@ -35,10 +35,7 @@ imports:
   - private/protocol/query
   - private/protocol/query/queryutil
   - private/protocol/rest
-  - private/protocol/restjson
   - private/protocol/xml/xmlutil
-  - service/batch
-  - service/batch/batchiface
   - service/dynamodb
   - service/dynamodb/dynamodbattribute
   - service/dynamodb/dynamodbiface
@@ -48,7 +45,7 @@ imports:
 - name: github.com/Clever/discovery-go
   version: 2e485eaaf026d527548740ceff178c8859fcaa07
 - name: github.com/Clever/go-process-metrics
-  version: 17c3da159c36ee2bbb4198c8eeada7f68184350f
+  version: 5944a49b5051ebcc10feb08724689740b4eefa28
   subpackages:
   - metrics
 - name: github.com/davecgh/go-spew
@@ -62,7 +59,7 @@ imports:
 - name: github.com/go-errors/errors
   version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/go-ini/ini
-  version: 5b3e00af70a9484542169a976dcab8d03e601a17
+  version: f384f410798cbe7cdce40eec40b79ed32bb4f1ad
 - name: github.com/go-openapi/analysis
   version: 8ed83f2ea9f00f945516462951a288eaa68bf0d6
 - name: github.com/go-openapi/errors
@@ -72,17 +69,17 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/loads
-  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
+  version: c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820
 - name: github.com/go-openapi/runtime
   version: e8231e16de5bcda9839e03ae07c5c96a1fd82041
 - name: github.com/go-openapi/spec
-  version: 48c2a7185575f9103a5a3863eff950bb776899d2
+  version: 84b5bee7bcb76f3d17bcbaf421bac44bd5709ca6
 - name: github.com/go-openapi/strfmt
   version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
 - name: github.com/go-openapi/swag
   version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/go-openapi/validate
-  version: dc8a684882cf70c9a529887104340f44e0e138e5
+  version: b6cfc35bf312e6fb320d85ed9fc3ac408dcb8694
 - name: github.com/gogo/protobuf
   version: 117892bf1866fbaa2318c03e50e40564c8845457
   subpackages:
@@ -92,7 +89,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 130e6b02ab059e7b717a096f397c5b60111cae74
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
   - proto
   - ptypes
@@ -119,7 +116,7 @@ imports:
   - thrift_0_9_2/lib/go/thrift
   - thrift_rpc
 - name: github.com/mailru/easyjson
-  version: 3fd5e860b68f3cc81671ece2e226c78a6bbf54d3
+  version: 4d347d79dea0067c945f374f990601decb08abb5
   subpackages:
   - buffer
   - jlexer
@@ -147,6 +144,11 @@ imports:
   version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
+- name: github.com/signalfx/golib
+  version: cb7680940d605b817db79790c241eed2a00fa6e6
+  subpackages:
+  - datapoint
+  - errors
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
@@ -164,7 +166,7 @@ imports:
   subpackages:
   - models
 - name: golang.org/x/net
-  version: 1087133bc4af3073e18add999345c6ae75918503
+  version: 4b14673ba32bee7f5ac0f990a48f033919fd418b
   subpackages:
   - context
   - context/ctxhttp
@@ -175,7 +177,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: c01e4764d870b77f8abe5096ee19ad20d80e8075
+  version: 6eab0e8f74e86c598ec3b6fad4888e0c11482d48
   subpackages:
   - secure/bidirule
   - transform
@@ -187,9 +189,10 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: faebfcb7bf4702e9cf359637e8893ae415eb8705
+  version: 0d57c57a68d6c3f0cf1d708ab380b10e092c759f
   subpackages:
   - balancer
+  - balancer/roundrobin
   - codes
   - connectivity
   - credentials
@@ -201,14 +204,12 @@ imports:
   - naming
   - peer
   - resolver
+  - resolver/dns
+  - resolver/passthrough
   - stats
   - status
   - tap
   - transport
-- name: gopkg.in/Clever/kayvee-go.v3
-  version: 056c92dcc68b40c5d6045f755197b3776f914154
-  subpackages:
-  - logger
 - name: gopkg.in/Clever/kayvee-go.v6
   version: e1e6fd8184162847c1123645e7058347a2fd3959
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,3 +31,7 @@ import:
   repo: git@github.com:Clever/ddbsync.git
 - package: github.com/mohae/deepcopy
 - package: github.com/hashicorp/golang-lru
+- package: github.com/signalfx/golib
+  version: ^1.0.0
+  subpackages:
+  - datapoint

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -30,3 +30,12 @@ routes:
       value_field: "update-loop-lag-seconds"
       stat_type: "gauge"
       dimensions: []
+
+  get-execution-history-count:
+    matchers:
+      title: ["get-execution-history-count"]
+    output:
+      type: "alerts"
+      series: "workflow-manager.get-execution-history-count"
+      stat_type: "counter"
+      dimensions: []


### PR DESCRIPTION
Adds an implementation of sfniface.SFNAPI that intercepts calls to `GetExecutionHistoryPagesWithContext` and increments a counter. Logs the value of this counter and routes it to signalfx.

This should let us monitor our total request rate to this method, and also give us a good idea of how effective our strategies are around controlling our request rate.

It might also serve as template for doing this elsewhere in our code where we hit AWS API limits (I'm looking at you, ecs-metrics 😜 ) 