### PR TITLE
separate workflow summary update from history update

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -14,7 +14,8 @@ type WorkflowManager interface {
 	CreateWorkflow(def models.WorkflowDefinition, input string, namespace string, queue string, tags map[string]interface{}) (*models.Workflow, error)
 	RetryWorkflow(workflow models.Workflow, startAt, input string) (*models.Workflow, error)
 	CancelWorkflow(workflow *models.Workflow, reason string) error
-	UpdateWorkflowStatus(workflow *models.Workflow) error
+	UpdateWorkflowSummary(workflow *models.Workflow) error
+	UpdateWorkflowHistory(workflow *models.Workflow) error
 }
 
 // PollForPendingWorkflowsAndUpdateStore polls the store for workflows in a pending state and
@@ -78,6 +79,6 @@ func checkPendingWorkflows(wm WorkflowManager, thestore store.Store) (string, er
 	}
 
 	logPendingWorkflowsLocked(wf)
-	err = wm.UpdateWorkflowStatus(&wf)
+	err = wm.UpdateWorkflowSummary(&wf)
 	return wfLockedID, err
 }

--- a/handler.go
+++ b/handler.go
@@ -212,8 +212,11 @@ func (h Handler) GetWorkflowByID(ctx context.Context, workflowID string) (*model
 		return &models.Workflow{}, err
 	}
 
-	err = h.manager.UpdateWorkflowStatus(&workflow)
-	if err != nil {
+	if err := h.manager.UpdateWorkflowSummary(&workflow); err != nil {
+		return &models.Workflow{}, err
+	}
+
+	if err := h.manager.UpdateWorkflowHistory(&workflow); err != nil {
 		return &models.Workflow{}, err
 	}
 


### PR DESCRIPTION
This PR changes the update loop to only update the "summary" portion of the workflow object, eliminating calls to `DescribeExecutionHistory` in that loop.

In my mind this PR is an intermediate step... I think in the long run the workflow object should probably split in two and have one object that represents a summary and another that represents a history (basically the same split that AWS has in their data model between an Execution and an ExecutionHistory).