### PR TITLE
add counter for describe execution calls

### DIFF
--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"time"
 
+	"github.com/Clever/workflow-manager/executor/sfncounter"
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
@@ -47,8 +48,9 @@ func logPendingWorkflowsLocked(wf models.Workflow) {
 	})
 }
 
-func LogGetExecutionHistoryCount(value int64) {
-	log.InfoD("get-execution-history-count", logger.M{
-		"value": value,
+func LogSFNCounts(counters sfncounter.Counters) {
+	log.InfoD("sfn-api-request-counters", logger.M{
+		"get-execution-history": counters.GetExecutionHistory,
+		"describe-execution":    counters.DescribeExecution,
 	})
 }

--- a/executor/log_helpers_test.go
+++ b/executor/log_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Clever/workflow-manager/executor/sfncounter"
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -31,16 +32,21 @@ func TestRoutingRules(t *testing.T) {
 		counts := mocklog.RuleCounts()
 		assert.Equal(t, 1, len(counts))
 		assert.Contains(t, counts, "update-loop-lag-alert")
-		assert.Equal(t, counts["update-loop-lag-alert"], 1)
+		assert.Equal(t, 1, counts["update-loop-lag-alert"])
 	})
 
-	t.Run("get-execution-history-count", func(t *testing.T) {
+	t.Run("sfn-counters", func(t *testing.T) {
 		mocklog := logger.NewMockCountLogger("workflow-manager")
 		log = mocklog
-		LogGetExecutionHistoryCount(100)
+		LogSFNCounts(sfncounter.Counters{
+			GetExecutionHistory: 100,
+			DescribeExecution:   200,
+		})
 		counts := mocklog.RuleCounts()
-		assert.Equal(t, 1, len(counts))
-		assert.Contains(t, counts, "get-execution-history-count")
-		assert.Equal(t, counts["get-execution-history-count"], 1)
+		assert.Equal(t, 2, len(counts))
+		assert.Contains(t, counts, "get-execution-history-counter")
+		assert.Contains(t, counts, "describe-execution-counter")
+		assert.Equal(t, 1, counts["get-execution-history-counter"])
+		assert.Equal(t, 1, counts["describe-execution-counter"])
 	})
 }

--- a/executor/sfncounter/sfn.go
+++ b/executor/sfncounter/sfn.go
@@ -12,6 +12,7 @@ import (
 type SFNCounter struct {
 	sfniface.SFNAPI
 	getExecutionHistory *CumulativeBucket
+	describeExecution   *CumulativeBucket
 }
 
 // New creates a new SFNCounter
@@ -22,25 +23,29 @@ func New(sfnapi sfniface.SFNAPI) *SFNCounter {
 			MetricName: "get-execution-history",
 			Dimensions: map[string]string{},
 		},
+		describeExecution: &CumulativeBucket{
+			MetricName: "describe-execution",
+			Dimensions: map[string]string{},
+		},
 	}
 }
 
-// countGetExecutionHistory counts GetExectuionHistory requests.
+// countGetExecutionHistoryRequest counts GetExecutionHistory requests.
 // These requests are limited via a token bucket of size 250 with refill rate of 5/sec.
 // See http://docs.aws.amazon.com/step-functions/latest/dg/limits.html.
 func (s *SFNCounter) countGetExecutionHistoryRequest(*request.Request) {
 	s.getExecutionHistory.Add(1)
 }
 
-// GetExecutionHistoryPagesWithContext is counted by injecting a request option that increments the count.
+// GetExecutionHistoryPagesWithContext counts GetExecutionHistory requests by injecting a request option that increments the counter.
 // This captures all underlying GetExectuionHistory HTTP requests.
 func (s *SFNCounter) GetExecutionHistoryPagesWithContext(ctx aws.Context, i *sfn.GetExecutionHistoryInput, fn func(*sfn.GetExecutionHistoryOutput, bool) bool, opts ...request.Option) error {
 	opts = append(opts, s.countGetExecutionHistoryRequest)
 	return s.SFNAPI.GetExecutionHistoryPagesWithContext(ctx, i, fn, opts...)
 }
 
-// GetExecutionHistoryCount returns the cumulative count of requests to GetExecutionHistory.
-func (s *SFNCounter) GetExecutionHistoryCount() datapoint.IntValue {
+// getExecutionHistoryCounter returns the cumulative counter of requests to GetExecutionHistory.
+func (s *SFNCounter) getExecutionHistoryCounter() datapoint.IntValue {
 	// cumulative bucket tracks count, sum, and sum squares.
 	// these are int, int, and float values, respectively
 	// since we're always adding 1 (`Add(1)` above) these datapoints all be the same.
@@ -52,4 +57,45 @@ func (s *SFNCounter) GetExecutionHistoryCount() datapoint.IntValue {
 		}
 	}
 	return nil
+}
+
+// countDescribeExecutionRequest counts DescribeExecution requests.
+// These requests are limited via a token bucket of size 200 with refill rate of 2/sec.
+// See http://docs.aws.amazon.com/step-functions/latest/dg/limits.html.
+func (s *SFNCounter) countDescribeExecutionRequest(*request.Request) {
+	s.describeExecution.Add(1)
+}
+
+// DescribeExecutionWithContext counts DescribeExecution requests by injecting a request option that increments the counter.
+func (s *SFNCounter) DescribeExecutionWithContext(ctx aws.Context, i *sfn.DescribeExecutionInput, opts ...request.Option) (*sfn.DescribeExecutionOutput, error) {
+	opts = append(opts, s.countDescribeExecutionRequest)
+	return s.SFNAPI.DescribeExecutionWithContext(ctx, i, opts...)
+}
+
+// describeExecutionCounter returns the cumulative counter of requests to describeExecution.
+func (s *SFNCounter) describeExecutionCounter() datapoint.IntValue {
+	dps := s.describeExecution.Datapoints()
+	for _, dp := range dps {
+		if iv, ok := dp.Value.(datapoint.IntValue); ok {
+			return iv
+		}
+	}
+	return nil
+}
+
+type Counters struct {
+	GetExecutionHistory int64
+	DescribeExecution   int64
+}
+
+// Counters returns all counter values
+func (s *SFNCounter) Counters() Counters {
+	var counters Counters
+	if val := s.getExecutionHistoryCounter(); val != nil {
+		counters.GetExecutionHistory = val.Int()
+	}
+	if val := s.describeExecutionCounter(); val != nil {
+		counters.DescribeExecution = val.Int()
+	}
+	return counters
 }

--- a/executor/sfncounter/sfn_test.go
+++ b/executor/sfncounter/sfn_test.go
@@ -15,7 +15,7 @@ func TestGetExecutionHistoryRequestCount(t *testing.T) {
 	defer mockController.Finish()
 	mockSFNAPI := mock_sfniface.NewMockSFNAPI(mockController)
 	countedSFN := New(mockSFNAPI)
-	// expect a request option to be added to the call to GetExecutionHistoryPagesWithContext
+	// expect a request option to be added
 	mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Eq(context.Background()), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil).
@@ -23,5 +23,19 @@ func TestGetExecutionHistoryRequestCount(t *testing.T) {
 	err := countedSFN.GetExecutionHistoryPagesWithContext(context.Background(), &sfn.GetExecutionHistoryInput{}, func(*sfn.GetExecutionHistoryOutput, bool) bool {
 		return true
 	})
+	require.Nil(t, err)
+}
+
+func TestDescribeExecutionRequestCount(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	mockSFNAPI := mock_sfniface.NewMockSFNAPI(mockController)
+	countedSFN := New(mockSFNAPI)
+	// expect a request option to be added
+	mockSFNAPI.EXPECT().
+		DescribeExecutionWithContext(gomock.Eq(context.Background()), gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(1)
+	_, err := countedSFN.DescribeExecutionWithContext(context.Background(), &sfn.DescribeExecutionInput{})
 	require.Nil(t, err)
 }

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -255,7 +255,7 @@ func (wm *SFNWorkflowManager) CancelWorkflow(workflow *models.Workflow, reason s
 	// attempt to describe execution
 	wd := workflow.WorkflowDefinition
 	execARN := wm.executionARN(workflow, wd)
-	describeOutput, err := wm.sfnapi.DescribeExecution(&sfn.DescribeExecutionInput{
+	describeOutput, err := wm.sfnapi.DescribeExecutionWithContext(context.TODO(), &sfn.DescribeExecutionInput{
 		ExecutionArn: aws.String(execARN),
 	})
 	if err != nil {
@@ -336,7 +336,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(workflow *models.Workflow) e
 		stateMachineName(wd.Name, wd.Version, workflow.Namespace, wd.StateMachine.StartAt),
 		workflow.ID,
 	)
-	describeOutput, err := wm.sfnapi.DescribeExecution(&sfn.DescribeExecutionInput{
+	describeOutput, err := wm.sfnapi.DescribeExecutionWithContext(context.TODO(), &sfn.DescribeExecutionInput{
 		ExecutionArn: aws.String(execARN),
 	})
 	if err != nil {

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -112,7 +112,7 @@ func TestCancelWorkflow(t *testing.T) {
 	reason := "i have my reasons"
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -131,7 +131,7 @@ func TestCancelWorkflow(t *testing.T) {
 	t.Log("Verify both status and status reason are updated if execution has already failed.")
 	newReason := "seriously, stop asking"
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -150,7 +150,7 @@ func TestCancelWorkflow(t *testing.T) {
 	t.Log("Verify errors are propagated.")
 	cancelError := fmt.Errorf("nope")
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -165,7 +165,7 @@ func TestCancelWorkflow(t *testing.T) {
 	workflow.Status = models.WorkflowStatusFailed
 	c.updateWorkflow(t, workflow)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -228,7 +228,7 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -275,7 +275,7 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -319,7 +319,7 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -396,7 +396,7 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 	executionOutput := `{"output": true}`
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -456,7 +456,7 @@ func TestUpdateWorkflowStatusJobCancelled(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -498,7 +498,7 @@ func TestUpdateWorkflowStatusWorkflowCancelledAfterJobSucceeded(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -543,13 +543,13 @@ func TestUpdateWorkflowStatusExecutionNotFoundRetry(t *testing.T) {
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	// fail the first time
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(nil, awserr.New(sfn.ErrCodeExecutionDoesNotExist, "test", errors.New("")))
 	// then success
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(&sfn.DescribeExecutionOutput{
@@ -596,7 +596,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundStopRetry(t *testing.T) {
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		DescribeExecution(&sfn.DescribeExecutionInput{
+		DescribeExecutionWithContext(gomock.Any(), &sfn.DescribeExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 		}).
 		Return(nil, awserr.New(sfn.ErrCodeExecutionDoesNotExist,

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -31,11 +31,22 @@ routes:
       stat_type: "gauge"
       dimensions: []
 
-  get-execution-history-count:
+  get-execution-history-counter:
     matchers:
-      title: ["get-execution-history-count"]
+      title: ["sfn-api-request-counters"]
     output:
       type: "alerts"
-      series: "workflow-manager.get-execution-history-count"
+      series: "workflow-manager.get-execution-history-counter"
       stat_type: "counter"
+      value_field: "get-execution-history"
+      dimensions: []
+
+  describe-execution-counter:
+    matchers:
+      title: ["sfn-api-request-counters"]
+    output:
+      type: "alerts"
+      series: "workflow-manager.describe-execution-counter"
+      stat_type: "counter"
+      value_field: "describe-execution"
       dimensions: []

--- a/main.go
+++ b/main.go
@@ -124,8 +124,6 @@ func getEnvVarOrDefault(envVarName, defaultIfEmpty string) string {
 func logSFNCounts(sfnCounter *sfncounter.SFNCounter) {
 	ticker := time.NewTicker(10 * time.Second)
 	for _ = range ticker.C {
-		if val := sfnCounter.GetExecutionHistoryCount(); val != nil {
-			executor.LogGetExecutionHistoryCount(val.Int())
-		}
+		executor.LogSFNCounts(sfnCounter.Counters())
 	}
 }


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2620

Adds a counter for DescribeExecution calls. This API method has a limit of 2 per second, and is now the only method called in the update loop. We should monitor it. I've also requested an increase to 50 per second with AWS