### PR TITLE
Prepend defaultRetry to conform to spec

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -94,7 +94,9 @@ func stateMachineWithDefaultRetriers(oldSM models.SLStateMachine) *models.SLStat
 			}
 		}
 		if injectRetry && state.Type == models.SLStateTypeTask {
-			state.Retry = append(state.Retry, defaultSFNCLICommandTerminatedRetrier)
+			// Add the default retry before user defined ones since Error=States.ALL must
+			// always be the last in the retry list and could be defined in the workflow definition
+			state.Retry = append([]*models.SLRetrier{defaultSFNCLICommandTerminatedRetrier}, state.Retry...)
 		}
 		sm.States[stateName] = state
 	}


### PR DESCRIPTION
From https://states-language.net/spec.html#error-names

> The reserved name “States.ALL” in a Retrier’s “ErrorEquals” field is a
wild-card and matches any Error Name. *Such a value MUST appear alone in
the “ErrorEquals” array and MUST appear in the last Retrier in the
“Retry” array.*

- [ na ] Update swagger.yml version
- [ na ] Run "make generate"
