### PR TITLE
Remove workflow sfn create fail

### DIFF
--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -12,11 +12,11 @@ var log = logger.New("workflow-manager")
 
 func logJobStatus(job *models.Job, workflow *models.Workflow) {
 	log.InfoD("job-status", logger.M{
-		"id":            job.ID,
-		"workflow-id":   workflow.ID,
-		"workflow-name": workflow.WorkflowDefinition.Name,
-		"state":         job.State,
-		"status":        job.Status,
+		"id":                       job.ID,
+		"workflow-id":              workflow.ID,
+		"workflow-definition-name": workflow.WorkflowDefinition.Name,
+		"state":                    job.State,
+		"status":                   job.Status,
 		// 0 -> running; 1 -> failed;
 		// -1 -> cancelled by user; -2 -> abort due to dependecy failure
 		"value": resources.JobStatusToInt(job.Status),

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -211,10 +211,10 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition,
 		// since we failed to start execution, remove Workflow from store
 		if delErr := wm.store.DeleteWorkflowByID(workflow.ID); delErr != nil {
 			log.ErrorD("create-workflow", logger.M{
-				"id":            workflow.ID,
-				"workflow-name": workflow.WorkflowDefinition.Name,
-				"message":       "failed to delete stray workflow",
-				"error":         fmt.Sprintf("SFNError: %s;StoreError: %s", err, delErr),
+				"id": workflow.ID,
+				"workflow-definition-name": workflow.WorkflowDefinition.Name,
+				"message":                  "failed to delete stray workflow",
+				"error":                    fmt.Sprintf("SFNError: %s;StoreError: %s", err, delErr),
 			})
 		}
 

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -186,7 +186,12 @@ func (wm *SFNWorkflowManager) startExecution(stateMachineArn *string, workflowID
 	return err
 }
 
-func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition, input string, namespace string, queue string, tags map[string]interface{}) (*models.Workflow, error) {
+func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition,
+	input string,
+	namespace string,
+	queue string,
+	tags map[string]interface{}) (*models.Workflow, error) {
+
 	describeOutput, err := wm.describeOrCreateStateMachine(wd, namespace, queue)
 	if err != nil {
 		return nil, err

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -161,6 +161,14 @@ func (s MemoryStore) UpdateWorkflow(workflow models.Workflow) error {
 	return nil
 }
 
+func (s MemoryStore) DeleteWorkflowByID(workflowID string) error {
+	if _, ok := s.workflows[workflowID]; !ok {
+		return store.NewNotFound(workflowID)
+	}
+	delete(s.workflows, workflowID)
+	return nil
+}
+
 func (s MemoryStore) GetWorkflows(
 	query *models.WorkflowQuery,
 ) ([]models.Workflow, string, error) {

--- a/store/store.go
+++ b/store/store.go
@@ -21,6 +21,7 @@ type Store interface {
 	DeleteStateResource(name, namespace string) error
 
 	SaveWorkflow(workflow models.Workflow) error
+	DeleteWorkflowByID(workflowID string) error
 	UpdateWorkflow(workflow models.Workflow) error
 	GetWorkflowByID(id string) (models.Workflow, error)
 	GetWorkflows(query *models.WorkflowQuery) ([]models.Workflow, string, error)


### PR DESCRIPTION
Progress on INFRA-2607: Job history occasionally missing from workflows

I was able to reproduce a case where we failed to startExecution due to rate limiting and then status updates kept failing since we could not find the execution. This change attempts to make `CreateWorkflow` to be more transactional. 

TODO: add tests for this condition. ✅ 

- [ na ] Update swagger.yml version
- [ na ] Run "make generate"