### PR TITLE
Fix job start date to be when the activity was started.

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -465,6 +465,10 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(workflow *models.Workflow) e
 				job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
 				job.Attempts = []*models.JobAttempt{}
 				job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+				if *evt.Type != sfn.HistoryEventTypeTaskStateEntered {
+					// Non-task states technically start immediately, since they don't wait on resources:
+					job.StartedAt = job.CreatedAt
+				}
 				job.Status = models.JobStatusCreated
 				if details := evt.StateEnteredEventDetails; details != nil {
 					stateName := aws.StringValue(details.Name)

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -465,7 +465,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(workflow *models.Workflow) e
 				job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
 				job.Attempts = []*models.JobAttempt{}
 				job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-				job.StartedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				job.Status = models.JobStatusCreated
 				if details := evt.StateEnteredEventDetails; details != nil {
 					stateName := aws.StringValue(details.Name)
@@ -496,7 +495,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(workflow *models.Workflow) e
 						TaskARN:   oldJobData.Container,
 					})
 					job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-					job.StartedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 					job.Input = oldJobData.Input
 					job.State = oldJobData.State
 					job.StateResource = &models.StateResource{
@@ -509,6 +507,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(workflow *models.Workflow) e
 				job.Status = models.JobStatusQueued
 			case sfn.HistoryEventTypeActivityStarted:
 				job.Status = models.JobStatusRunning
+				job.StartedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
 				if details := evt.ActivityStartedEventDetails; details != nil {
 					job.Container = aws.StringValue(details.WorkerName)
 				}


### PR DESCRIPTION
Basically, don't set `Job.StartedAt` until the job actually starts, so we have an idea of time waiting in queue for historical jobs.

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
