### PR TITLE
Fix default queue

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -194,12 +194,12 @@
 <a name="startworkflowrequest"></a>
 ### StartWorkflowRequest
 
-|Name|Description|Schema|
-|---|---|---|
-|**input**  <br>*optional*||string|
-|**namespace**  <br>*optional*||string|
-|**queue**  <br>*optional*|**Default** : `"default"`|string|
-|**workflowDefinition**  <br>*optional*||[WorkflowDefinitionRef](#workflowdefinitionref)|
+|Name|Schema|
+|---|---|
+|**input**  <br>*optional*|string|
+|**namespace**  <br>*optional*|string|
+|**queue**  <br>*optional*|string|
+|**workflowDefinition**  <br>*optional*|[WorkflowDefinitionRef](#workflowdefinitionref)|
 
 
 <a name="stateresource"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.6.12
+*Version* : 0.7.0
 
 
 ### URI scheme

--- a/gen-go/models/start_workflow_request.go
+++ b/gen-go/models/start_workflow_request.go
@@ -24,7 +24,7 @@ type StartWorkflowRequest struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// queue
-	Queue *string `json:"queue,omitempty"`
+	Queue string `json:"queue,omitempty"`
 
 	// tags: object with key-value pairs; keys and values should be strings
 	Tags map[string]interface{} `json:"tags,omitempty"`

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.6.12",
+  "version": "0.7.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/handler.go
+++ b/handler.go
@@ -153,9 +153,10 @@ func (h Handler) StartWorkflow(ctx context.Context, req *models.StartWorkflowReq
 		return &models.Workflow{}, err
 	}
 
-	if req.Queue == nil {
-		return &models.Workflow{}, fmt.Errorf("workflow queue cannot be nil")
+	if req.Queue == "" {
+		req.Queue = "default"
 	}
+
 	// verify request's tags (map[string]interface{}) are actually map[string]string
 	if err := validateTagsMap(req.Tags); err != nil {
 		return &models.Workflow{}, err

--- a/handler.go
+++ b/handler.go
@@ -162,7 +162,7 @@ func (h Handler) StartWorkflow(ctx context.Context, req *models.StartWorkflowReq
 		return &models.Workflow{}, err
 	}
 
-	return h.manager.CreateWorkflow(workflowDefinition, req.Input, req.Namespace, *req.Queue, req.Tags)
+	return h.manager.CreateWorkflow(workflowDefinition, req.Input, req.Namespace, req.Queue, req.Tags)
 }
 
 // GetWorkflows returns a summary of all workflows matching the given query.

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.6.12
+  version: 0.7.0
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -508,15 +508,18 @@ definitions:
     type: object
     properties:
       workflowDefinition:
+        # required
         $ref: '#/definitions/WorkflowDefinitionRef'
       input:
+        # required
         # format: json
         type: string
       namespace:
+        # required
         type: string
       queue:
+        # not required (defaults to "default")
         type: string
-        default: "default"
       tags:
         description: "tags: object with key-value pairs; keys and values should be strings"
         additionalProperties:


### PR DESCRIPTION
go-swagger wasn't doing the default for us (see https://github.com/Clever/workflow-manager/blob/18a48402b27c3b73804eb58d6edf4b29e7ff01b6/gen-go/models/start_workflow_request.go)

- [x] Update swagger.yml version
- [x] Run "make generate"
