### PR TITLE
Persist all previous job attempts when creating new ones.

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -494,7 +494,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(workflow *models.Workflow) e
 					oldJobData := *job
 					*job = models.Job{}
 					job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
-					job.Attempts = append(job.Attempts, &models.JobAttempt{
+					job.Attempts = append(oldJobData.Attempts, &models.JobAttempt{
 						Reason:    oldJobData.StatusReason,
 						StartedAt: oldJobData.StartedAt,
 						StoppedAt: oldJobData.StoppedAt,


### PR DESCRIPTION
Minor bug was causing the attempts array to contain only one previous attempt.

- [N/A] Update swagger.yml version
- [N/A] Run "make generate"
