### PR TITLE
Set ResolvedByUser if workflow succeeded/cancelled

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -389,6 +389,10 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(workflow *models.Workflow) e
 	if describeOutput.StopDate != nil {
 		workflow.StoppedAt = strfmt.DateTime(aws.TimeValue(describeOutput.StopDate))
 	}
+	if workflow.Status == models.WorkflowStatusCancelled || workflow.Status == models.WorkflowStatusSucceeded {
+		workflow.ResolvedByUser = true
+	}
+
 	workflow.Output = aws.StringValue(describeOutput.Output) // use for error or success  (TODO: actually this is only sent for success)
 	return wm.store.UpdateWorkflow(*workflow)
 }


### PR DESCRIPTION
Previously, we only set this flag if a user manually submitted it. In
practice, we want a simple query for all "unresolved" workflows versus
"resolved" ones.

- Unresolved: queued, running, failed (but not yet investigated)
- Resolved: succeeded, cancelled, failed (and investigated)

This change auto-resolves succeeded and cancelled, and leaves it up to
the user to manually resolve failed workflows.

- [x] Update swagger.yml version
- [x] Run "make generate"
