### PR TITLE
Disallow cancelling failed workflows

### DIFF
--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -216,6 +216,7 @@ func TestCancelWorkflow(t *testing.T) {
 	initialStatus := models.WorkflowStatusRunning
 	workflow.Status = initialStatus
 	c.saveWorkflow(t, workflow)
+	assert.Equal(t, false, workflow.ResolvedByUser)
 
 	t.Log("Verify execution is stopped and status reason is updated.")
 	reason := "i have my reasons"
@@ -228,6 +229,7 @@ func TestCancelWorkflow(t *testing.T) {
 		Return(&sfn.StopExecutionOutput{}, nil)
 	require.NoError(t, c.manager.CancelWorkflow(workflow, reason))
 	assert.Equal(t, initialStatus, workflow.Status)
+	assert.Equal(t, true, workflow.ResolvedByUser)
 	assert.Equal(t, reason, workflow.StatusReason)
 
 	t.Log("Failed Workflows cannot be cancelled.")

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -673,6 +673,7 @@ func (b byLastUpdatedTime) Less(i, j int) bool {
 // workflows ordered by their last updated time. Workflows with the oldest last updated
 // time are returned first.
 func (d DynamoDB) GetPendingWorkflowIDs() ([]string, error) {
+	// TODO: Replace this with ResolvedByUser?
 	var pendingWorkflows []models.Workflow
 	for _, statusToQuery := range []models.WorkflowStatus{models.WorkflowStatusQueued, models.WorkflowStatusRunning} {
 		query, err := ddbWorkflowSecondaryKeyStatusLastUpdated{


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2703

Previously, we allowed cancelling failed workflows as a workaround for
"resolving". We cancelled a failed job in order to manually acknowledge
that we were done investigating that job.

We recently added the concept ResolvedByUser in workflow-manager:
https://github.com/Clever/workflow-manager/pull/101

This means we can remove the overloaded idea of cancelling failed jobs,
and instead mark them as ResolvedByUser.

- [ ] Update swagger.yml version
- [ ] Run "make generate"
