### PR TITLE
Use UTC timezone when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	cp ./kvconfig.yml ./build/kvconfig.yml
 
 run: build
-	build/$(EXECUTABLE)
+	TZ=UTC build/$(EXECUTABLE)
 
 run-docker:
 	@docker run \


### PR DESCRIPTION
In Dev, this helps ensure that we don't persist data in two different
formats in DynamoDB. Otherwise, it's easy to mistakenly write data like

```
LastUpdated= 2017-10-20T17:42:31.394932656Z
LastUpdated= 2017-10-04T20:09:24.964107-07:00
```

If code isn't written carefully, this can lead to unexpected errors when
handling / sorting dates.

After this change, we'll ensure all dates are written in the first
format.

- [n/a ] Update swagger.yml version
- [n/a] Run "make generate"
