### PR TITLE
Set `ResolvedByUser = true` within `CancelWorkflow`

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -303,6 +303,7 @@ func (wm *SFNWorkflowManager) CancelWorkflow(workflow *models.Workflow, reason s
 	}
 
 	workflow.StatusReason = reason
+	workflow.ResolvedByUser = true
 	return wm.store.UpdateWorkflow(*workflow)
 }
 
@@ -389,7 +390,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(workflow *models.Workflow) e
 	if describeOutput.StopDate != nil {
 		workflow.StoppedAt = strfmt.DateTime(aws.TimeValue(describeOutput.StopDate))
 	}
-	if workflow.Status == models.WorkflowStatusCancelled || workflow.Status == models.WorkflowStatusSucceeded {
+	if workflow.Status == models.WorkflowStatusSucceeded {
 		workflow.ResolvedByUser = true
 	}
 


### PR DESCRIPTION
Followup to https://github.com/Clever/workflow-manager/pull/105

Previously, if a workflow was cancelled, it never got the resolvedByUser attribute set to true. We were attempting to update this bool during `UpdateWorkflowSummary`, but this function exits early if a `WorkflowIsDone` ... which includes being cancelled.

https://github.com/Clever/workflow-manager/blob/4fd44aeb0edeb7d46019cb5e355cdc83299d3533/executor/workflow_manager_sfn.go#L347

We now update it within `CancelWorkflow`