### PR TITLE
add lambda support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,11 +32,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/afex/hystrix-go"
-  packages = [
-    "hystrix",
-    "hystrix/metric_collector",
-    "hystrix/rolling"
-  ]
+  packages = ["hystrix","hystrix/metric_collector","hystrix/rolling"]
   revision = "f118cd938f786d24f46cc307981d8f63b7951020"
 
 [[projects]]
@@ -46,40 +42,9 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/json/jsonutil",
-    "private/protocol/jsonrpc",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/xml/xmlutil",
-    "service/dynamodb",
-    "service/dynamodb/dynamodbattribute",
-    "service/dynamodb/dynamodbiface",
-    "service/sfn",
-    "service/sfn/sfniface",
-    "service/sts"
-  ]
-  revision = "1b176c5c6b57adb03bb982c21930e708ebca5a77"
-  version = "v1.12.70"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/dynamodb","service/dynamodb/dynamodbattribute","service/dynamodb/dynamodbiface","service/sfn","service/sfn/sfniface","service/sts"]
+  revision = "0cbaf57ea311890e62f0b01652529295079e9e95"
+  version = "v1.12.71"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -90,6 +55,12 @@
   name = "github.com/donovanhide/eventsource"
   packages = ["."]
   revision = "b8f31a59085e69dd2678cf51840db2ac625cb741"
+
+[[projects]]
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/go-errors/errors"
@@ -166,24 +137,14 @@
 
 [[projects]]
   name = "github.com/golang/mock"
-  packages = [
-    "gomock",
-    "mockgen",
-    "mockgen/model"
-  ]
+  packages = ["gomock","mockgen","mockgen/model"]
   revision = "13f360950a79f5864a972c786a10a50e44b69541"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -200,10 +161,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
+  packages = [".","simplelru"]
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
@@ -219,22 +177,12 @@
 
 [[projects]]
   name = "github.com/lightstep/lightstep-tracer-go"
-  packages = [
-    ".",
-    "collectorpb",
-    "lightstep_thrift",
-    "thrift_0_9_2/lib/go/thrift",
-    "thrift_rpc"
-  ]
+  packages = [".","collectorpb","lightstep_thrift","thrift_0_9_2/lib/go/thrift","thrift_rpc"]
   revision = "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce"
 
 [[projects]]
   name = "github.com/mailru/easyjson"
-  packages = [
-    "buffer",
-    "jlexer",
-    "jwriter"
-  ]
+  packages = ["buffer","jlexer","jwriter"]
   revision = "4d347d79dea0067c945f374f990601decb08abb5"
 
 [[projects]]
@@ -251,20 +199,13 @@
 
 [[projects]]
   name = "github.com/opentracing/basictracer-go"
-  packages = [
-    ".",
-    "wire"
-  ]
+  packages = [".","wire"]
   revision = "1b32af207119a14b1b231d451df3ed04a72efebf"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [
-    ".",
-    "ext",
-    "log"
-  ]
+  packages = [".","ext","log"]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -281,10 +222,7 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = [
-    "assert",
-    "require"
-  ]
+  packages = ["assert","require"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -309,46 +247,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/zencoder/ddbsync"
-  packages = [
-    ".",
-    "models"
-  ]
+  packages = [".","models"]
   revision = "83dd4ef1834424d47a7cde4a7f4361cfabbd7564"
   source = "git@github.com:Clever/ddbsync.git"
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "lex/httplex",
-    "trace"
-  ]
+  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "c73622c77280266305273cb545f54516ced95b93"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable",
-    "width"
-  ]
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
 
 [[projects]]
@@ -358,48 +268,19 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/roundrobin",
-    "codes",
-    "connectivity",
-    "credentials",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
   revision = "c91118c8fa0e1821c8fb860e15aaae5e6acb1add"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  packages = [
-    ".",
-    "logger",
-    "middleware",
-    "router"
-  ]
+  packages = [".","logger","middleware","router"]
   revision = "e1e6fd8184162847c1123645e7058347a2fd3959"
   version = "v6.10.0"
 
 [[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
-  packages = [
-    "bson",
-    "internal/json"
-  ]
+  packages = ["bson","internal/json"]
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
@@ -417,6 +298,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "859e228fa4699e085b703a5adecff84947dd325aba0719c37e83a9ec1b6c4d34"
+  inputs-digest = "4cfca21b0ba14c7b8a4e3e3458fc9beb2e3703026543610e04cd50475c8d9fde"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -239,7 +239,7 @@
 
 <a name="stateresourcetype"></a>
 ### StateResourceType
-*Type* : enum (JobDefinitionARN, ActivityARN)
+*Type* : enum (JobDefinitionARN, ActivityARN, LambdaFunctionARN)
 
 
 <a name="workflow"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.8.3
+*Version* : 0.9.0
 
 
 ### URI scheme
@@ -17,6 +17,3 @@ Orchestrator for AWS Step Functions
 ### Produces
 
 * `application/json`
-
-
-

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -71,6 +71,10 @@ func TestStateMachineWithFullActivityARNs(t *testing.T) {
 				Type:     models.SLStateTypeTask,
 				Resource: "resource-name",
 			},
+			"foostatelambda": models.SLState{
+				Type:     models.SLStateTypeTask,
+				Resource: "lambda:resource-name",
+			},
 		},
 	}
 	smWithFullActivityARNs := stateMachineWithFullActivityARNs(sm, "region", "accountID", "namespace")
@@ -78,6 +82,10 @@ func TestStateMachineWithFullActivityARNs(t *testing.T) {
 		"foostate": models.SLState{
 			Type:     models.SLStateTypeTask,
 			Resource: "arn:aws:states:region:accountID:activity:namespace--resource-name",
+		},
+		"foostatelambda": models.SLState{
+			Type:     models.SLStateTypeTask,
+			Resource: "arn:aws:lambda:region:accountID:function:namespace--resource-name",
 		},
 	}, smWithFullActivityARNs.States)
 }

--- a/gen-go/models/state_resource_type.go
+++ b/gen-go/models/state_resource_type.go
@@ -23,6 +23,8 @@ const (
 	StateResourceTypeJobDefinitionARN StateResourceType = "JobDefinitionARN"
 	// StateResourceTypeActivityARN captures enum value "ActivityARN"
 	StateResourceTypeActivityARN StateResourceType = "ActivityARN"
+	// StateResourceTypeLambdaFunctionARN captures enum value "LambdaFunctionARN"
+	StateResourceTypeLambdaFunctionARN StateResourceType = "LambdaFunctionARN"
 )
 
 // for schema
@@ -30,7 +32,7 @@ var stateResourceTypeEnum []interface{}
 
 func init() {
 	var res []StateResourceType
-	if err := json.Unmarshal([]byte(`["JobDefinitionARN","ActivityARN"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["JobDefinitionARN","ActivityARN","LambdaFunctionARN"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.8.3
+  version: 0.9.0
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -619,6 +619,7 @@ definitions:
     enum:
       - "JobDefinitionARN"
       - "ActivityARN"
+      - "LambdaFunctionARN"
 
   # States Language Types: https://states-language.net/spec.html
   SLStateMachine:


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2781

Adds support for interpreting workflow definitions that contain lambda resources, e.g.
```yml
manager: step-functions
name: cil-reliability-dashboard
stateMachine:
  Version: '1.0'
  StartAt: start
  TimeoutSeconds: 14400 # 4 hours
  States:
    start:
      Type: Task
      Resource: lambda:cil-reliability-dashboard # <--- 
      TimeoutSeconds: 3600  # 1h
      HeartbeatSeconds: 30
      Retry:
        - MaxAttempts: 2
          ErrorEquals: [ "States.ALL" ]
      End: true
```