### PR TITLE
Optimize `make build` for faster local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 
 RUN apk update && apk add ca-certificates
-COPY build/workflow-manager /bin/workflow-manager
+COPY bin/workflow-manager /bin/workflow-manager
 COPY kvconfig.yml /bin/kvconfig.yml
 
 CMD ["/bin/workflow-manager", "--addr=0.0.0.0:80"]

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ dynamodb-test:
 	./run_dynamodb_store_test.sh
 
 build:
-	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(EXECUTABLE) $(PKG)
-	cp ./kvconfig.yml ./build/kvconfig.yml
+	$(call golang-build,$(PKG),$(EXECUTABLE))
+	cp ./kvconfig.yml ./bin/kvconfig.yml
 
 run: build
-	TZ=UTC build/$(EXECUTABLE)
+	TZ=UTC bin/$(EXECUTABLE)
 
 run-docker:
 	@docker run \


### PR DESCRIPTION

Context: https://github.com/Clever/dev-handbook/pull/103/

When we run `ark start --local`, it's not necessary to do a CGO build.
We only need CGO when building the go binary to put into an Alpine linux Docker image.

Doing a non-CGO build locally can decrease build times drastically, ~10x faster

_NOTE_: Assuming a passing build, unless you reject the PR, I will auto-merge after ~1 day.