### PR TITLE
Update Loop using SQS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,6 +77,8 @@
     "service/dynamodb/dynamodbiface",
     "service/sfn",
     "service/sfn/sfniface",
+    "service/sqs",
+    "service/sqs/sqsiface",
     "service/sts"
   ]
   revision = "63324a33d7e42a386c04d4daec764a3de243492e"
@@ -418,6 +420,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "529e399b9790be801944ca5da8a83cba69f7f5c38a587001b933a0e300e857c8"
+  inputs-digest = "f1b79e260b282a33ade9dc3dbfea87e8071072dc17ad0cc5a4dd17857c9d8b4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include golang.mk
 include wag.mk
 
-.PHONY: all test build run dynamodb-test
+.PHONY: all test build run dynamodb-test mocks
 SHELL := /bin/bash
 APP_NAME ?= workflow-manager
 EXECUTABLE = $(APP_NAME)
@@ -42,9 +42,12 @@ generate: wag-generate-deps swagger2markup-cli-1.3.1.jar
 
 install_deps: golang-dep-vendor-deps
 	$(call golang-dep-vendor)
+	make mocks
+
+mocks:
 	go build -o bin/mockgen ./vendor/github.com/golang/mock/mockgen
 	mkdir -p mocks/
 	rm -rf mocks/*
-	for svc in dynamodb sfn; do \
+	for svc in dynamodb sfn sqs; do \
 	  bin/mockgen -package mocks -source ./vendor/github.com/aws/aws-sdk-go/service/$${svc}/$${svc}iface/interface.go > mocks/$${svc}.go; \
 	done

--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"time"
+
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
@@ -35,6 +37,13 @@ func logWorkflowStatusChange(workflow *models.Workflow, previousStatus models.Wo
 		"status":          workflow.Status,
 		// 0 -> running; 1 -> failed; -1 -> cancelled
 		"value": resources.WorkflowStatusToInt(workflow.Status),
+	})
+}
+
+func logPendingWorkflowUpdateLag(wf models.Workflow) {
+	log.InfoD("pending-workflow-update-lag", logger.M{
+		"id": wf.ID,
+		"update-loop-lag-seconds": int(time.Now().Sub(time.Time(wf.LastUpdated)) / time.Second),
 	})
 }
 

--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -1,8 +1,6 @@
 package executor
 
 import (
-	"time"
-
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
@@ -37,13 +35,6 @@ func logWorkflowStatusChange(workflow *models.Workflow, previousStatus models.Wo
 		"status":          workflow.Status,
 		// 0 -> running; 1 -> failed; -1 -> cancelled
 		"value": resources.WorkflowStatusToInt(workflow.Status),
-	})
-}
-
-func logPendingWorkflowsLocked(wf models.Workflow) {
-	log.InfoD("pending-workflows-locked", logger.M{
-		"id": wf.ID,
-		"update-loop-lag-seconds": int(time.Now().Sub(time.Time(wf.LastUpdated)) / time.Second),
 	})
 }
 

--- a/executor/log_helpers_test.go
+++ b/executor/log_helpers_test.go
@@ -2,10 +2,7 @@ package executor
 
 import (
 	"testing"
-	"time"
 
-	"github.com/Clever/workflow-manager/gen-go/models"
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
@@ -18,22 +15,6 @@ func init() {
 }
 
 func TestRoutingRules(t *testing.T) {
-	t.Run("update-loop-lag-alert", func(t *testing.T) {
-		mocklog := logger.NewMockCountLogger("workflow-manager")
-		log = mocklog
-		logPendingWorkflowsLocked(models.Workflow{
-			WorkflowSummary: models.WorkflowSummary{
-				ID:                 "id",
-				LastUpdated:        strfmt.DateTime(time.Now()),
-				WorkflowDefinition: &models.WorkflowDefinition{},
-			},
-		})
-		counts := mocklog.RuleCounts()
-		assert.Equal(t, 1, len(counts))
-		assert.Contains(t, counts, "update-loop-lag-alert")
-		assert.Equal(t, 1, counts["update-loop-lag-alert"])
-	})
-
 	t.Run("aws-sdk-go-counter", func(t *testing.T) {
 		mocklog := logger.NewMockCountLogger("workflow-manager")
 		log = mocklog

--- a/executor/log_helpers_test.go
+++ b/executor/log_helpers_test.go
@@ -2,7 +2,10 @@ package executor
 
 import (
 	"testing"
+	"time"
 
+	"github.com/Clever/workflow-manager/gen-go/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
@@ -15,6 +18,22 @@ func init() {
 }
 
 func TestRoutingRules(t *testing.T) {
+	t.Run("update-loop-lag-alert", func(t *testing.T) {
+		mocklog := logger.NewMockCountLogger("workflow-manager")
+		log = mocklog
+		logPendingWorkflowUpdateLag(models.Workflow{
+			WorkflowSummary: models.WorkflowSummary{
+				ID:                 "id",
+				LastUpdated:        strfmt.DateTime(time.Now()),
+				WorkflowDefinition: &models.WorkflowDefinition{},
+			},
+		})
+		counts := mocklog.RuleCounts()
+		assert.Equal(t, 1, len(counts))
+		assert.Contains(t, counts, "update-loop-lag-alert")
+		assert.Equal(t, 1, counts["update-loop-lag-alert"])
+	})
+
 	t.Run("aws-sdk-go-counter", func(t *testing.T) {
 		mocklog := logger.NewMockCountLogger("workflow-manager")
 		log = mocklog

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
@@ -27,14 +26,12 @@ type WorkflowManager interface {
 // PollForPendingWorkflowsAndUpdateStore polls an SQS queue for workflows needing an update.
 // It will stop polling when the context is done.
 func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManager, thestore store.Store, sqsapi sqsiface.SQSAPI, sqsQueueURL string) {
-	ticker := time.NewTicker(500 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():
-			log.InfoD("poll-for-pending-workflows-done", logger.M{})
-			ticker.Stop()
+			log.Info("poll-for-pending-workflows-done")
 			return
-		case <-ticker.C:
+		default:
 			out, err := sqsapi.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 				MaxNumberOfMessages: aws.Int64(10),
 				QueueUrl:            aws.String(sqsQueueURL),

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -100,5 +100,7 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 		return "", err
 	}
 
+	logPendingWorkflowUpdateLag(wf)
+
 	return wfID, nil
 }

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -2,11 +2,16 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/store"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 )
 
 // WorkflowManager is the interface for creating, stopping and checking status for Workflows
@@ -18,9 +23,9 @@ type WorkflowManager interface {
 	UpdateWorkflowHistory(workflow *models.Workflow) error
 }
 
-// PollForPendingWorkflowsAndUpdateStore polls the store for workflows in a pending state and
-// attempts to update them. It will stop polling when the context is done.
-func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManager, thestore store.Store) {
+// PollForPendingWorkflowsAndUpdateStore polls an SQS queue for workflows needing an update.
+// It will stop polling when the context is done.
+func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManager, thestore store.Store, sqsapi sqsiface.SQSAPI) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	for {
 		select {
@@ -29,7 +34,7 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			if id, err := checkPendingWorkflows(wm, thestore); err != nil {
+			if id, err := checkPendingWorkflows(wm, thestore, sqsapi); err != nil {
 				log.ErrorD("poll-for-pending-workflows", logger.M{"id": id, "error": err.Error()})
 			} else {
 				log.InfoD("poll-for-pending-workflows", logger.M{"id": id})
@@ -38,47 +43,60 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 	}
 }
 
-func lockAvailableWorkflow(thestore store.Store, workflowIDs []string) (string, error) {
-	for _, wfID := range workflowIDs {
-		if err := thestore.LockWorkflow(wfID); err == nil {
-			return wfID, nil
-		} else if err != store.ErrWorkflowLocked {
-			// an error reading from the Store
-			return "", err
-		}
-	}
-	return "", nil
-}
-
-func checkPendingWorkflows(wm WorkflowManager, thestore store.Store) (string, error) {
-	wfIDs, err := thestore.GetPendingWorkflowIDs()
+func checkPendingWorkflows(wm WorkflowManager, thestore store.Store, sqsapi sqsiface.SQSAPI) (string, error) {
+	// TODO: use context?
+	out, err := sqsapi.ReceiveMessage(&sqs.ReceiveMessageInput{
+		MaxNumberOfMessages: aws.Int64(1),
+		QueueUrl:            aws.String("https://sqs.us-west-1.amazonaws.com/589690932525/workflow-manager-update-loop-dev"), // TODO
+	})
 	if err != nil {
 		return "", err
 	}
 
-	// attempt to lock one of the workflows for updating
-	wfLockedID, err := lockAvailableWorkflow(thestore, wfIDs)
+	if len(out.Messages) == 0 {
+		return "n/a", nil
+	}
+
+	// TODO: update this + MaxNumberOfMessages to loop over many
+	m := out.Messages[0]
+
+	fmt.Println(m)
+	for key, val := range m.MessageAttributes {
+		fmt.Println(key, *val)
+	}
+	//wfID, ok := m.MessageAttributes["workflow-id"]
+	wfID := *m.Body
+	//if !ok {
+	//// Cleanup malformed messages
+	//_, err = sqsapi.DeleteMessage(&sqs.DeleteMessageInput{
+	//QueueUrl:      aws.String("https://sqs.us-west-1.amazonaws.com/589690932525/workflow-manager-update-loop-dev"), // TODO
+	//ReceiptHandle: m.ReceiptHandle,
+	//})
+	//if err != nil {
+	//return "", err
+	//}
+
+	//return "", fmt.Errorf("SQS message lacks 'workflow-id' attribute")
+	//}
+
+	wf, err := thestore.GetWorkflowByID(wfID)
 	if err != nil {
 		return "", err
 	}
-	if wfLockedID == "" {
-		log.InfoD("pending-workflows-noop", logger.M{"pending": len(wfIDs)})
-		return "", nil
-	}
 
-	defer func() {
-		log.InfoD("pending-workflows-unlocked", logger.M{"id": wfLockedID})
-		if err := thestore.UnlockWorkflow(wfLockedID); err != nil {
-			log.ErrorD("pending-workflows-unlock-error", logger.M{"id": wfLockedID, "error": err.Error()})
-		}
-	}()
-
-	wf, err := thestore.GetWorkflowByID(wfLockedID)
-	if err != nil {
-		return wfLockedID, err
-	}
-
-	logPendingWorkflowsLocked(wf)
 	err = wm.UpdateWorkflowSummary(&wf)
-	return wfLockedID, err
+	if err != nil {
+		return "", err
+	}
+
+	// Delete message from queue
+	_, err = sqsapi.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      aws.String("https://sqs.us-west-1.amazonaws.com/589690932525/workflow-manager-update-loop-dev"), // TODO
+		ReceiptHandle: m.ReceiptHandle,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return wfID, nil
 }

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -36,7 +36,7 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 			return
 		case <-ticker.C:
 			out, err := sqsapi.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
-				MaxNumberOfMessages: aws.Int64(1),
+				MaxNumberOfMessages: aws.Int64(10),
 				QueueUrl:            aws.String(sqsQueueURL),
 			})
 			if err != nil {

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -238,11 +237,7 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition,
 	}
 
 	// start update loop for this workflow
-	_, err = wm.sqsapi.SendMessage(&sqs.SendMessageInput{
-		MessageBody:  aws.String(workflow.ID),
-		QueueUrl:     aws.String(wm.sqsQueueURL),
-		DelaySeconds: aws.Int64(30),
-	})
+	err = createPendingWorkflow(context.TODO(), workflow.ID, wm.sqsapi, wm.sqsQueueURL)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -237,14 +237,13 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition,
 		return nil, err
 	}
 
-	//mav := &sqs.MessageAttributeValue{}
+	// start update loop for this workflow
 	_, err = wm.sqsapi.SendMessage(&sqs.SendMessageInput{
-		MessageBody: aws.String(workflow.ID),
-		QueueUrl:    aws.String(wm.sqsQueueURL),
-		//MessageAttributes: map[string]*sqs.MessageAttributeValue{"workflow-id": mav.SetStringValue(workflow.ID).SetDataType("String")},
+		MessageBody:  aws.String(workflow.ID),
+		QueueUrl:     aws.String(wm.sqsQueueURL),
+		DelaySeconds: aws.Int64(30),
 	})
 	if err != nil {
-		// failed to start update loop for Workflow
 		return nil, err
 	}
 

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -38,22 +38,24 @@ var defaultSFNCLICommandTerminatedRetrier = &models.SLRetrier{
 
 // SFNWorkflowManager manages workflows run through AWS Step Functions.
 type SFNWorkflowManager struct {
-	sfnapi    sfniface.SFNAPI
-	sqsapi    sqsiface.SQSAPI
-	store     store.Store
-	region    string
-	roleARN   string
-	accountID string
+	sfnapi      sfniface.SFNAPI
+	sqsapi      sqsiface.SQSAPI
+	store       store.Store
+	region      string
+	roleARN     string
+	accountID   string
+	sqsQueueURL string
 }
 
-func NewSFNWorkflowManager(sfnapi sfniface.SFNAPI, sqsapi sqsiface.SQSAPI, store store.Store, roleARN, region, accountID string) *SFNWorkflowManager {
+func NewSFNWorkflowManager(sfnapi sfniface.SFNAPI, sqsapi sqsiface.SQSAPI, store store.Store, roleARN, region, accountID, sqsQueueURL string) *SFNWorkflowManager {
 	return &SFNWorkflowManager{
-		sfnapi:    sfnapi,
-		sqsapi:    sqsapi,
-		store:     store,
-		roleARN:   roleARN,
-		region:    region,
-		accountID: accountID,
+		sfnapi:      sfnapi,
+		sqsapi:      sqsapi,
+		store:       store,
+		roleARN:     roleARN,
+		region:      region,
+		accountID:   accountID,
+		sqsQueueURL: sqsQueueURL,
 	}
 }
 
@@ -237,9 +239,8 @@ func (wm *SFNWorkflowManager) CreateWorkflow(wd models.WorkflowDefinition,
 
 	//mav := &sqs.MessageAttributeValue{}
 	_, err = wm.sqsapi.SendMessage(&sqs.SendMessageInput{
-		//MessageBody:       aws.String("n/a"),
 		MessageBody: aws.String(workflow.ID),
-		QueueUrl:    aws.String("https://sqs.us-west-1.amazonaws.com/589690932525/workflow-manager-update-loop-dev"), // TODO
+		QueueUrl:    aws.String(wm.sqsQueueURL),
 		//MessageAttributes: map[string]*sqs.MessageAttributeValue{"workflow-id": mav.SetStringValue(workflow.ID).SetDataType("String")},
 	})
 	if err != nil {

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -177,10 +177,11 @@ func TestCreateWorkflow(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, workflow.CreatedAt.String(), savedWorkflow.CreatedAt.String())
 		assert.Equal(t, workflow.ID, savedWorkflow.ID)
-		pendingIDs, err := c.store.GetPendingWorkflowIDs()
-		assert.Nil(t, err)
-		assert.Equal(t, 1, len(pendingIDs))
-		assert.Equal(t, workflow.ID, pendingIDs[0]) // current workflow is pending
+		// TODO: Verify it is pending in the queue
+		//pendingIDs, err := c.store.GetPendingWorkflowIDs()
+		//assert.Nil(t, err)
+		//assert.Equal(t, 1, len(pendingIDs))
+		//assert.Equal(t, workflow.ID, pendingIDs[0]) // current workflow is pending
 	})
 
 	t.Run("CreateWorkflow deletes workflow on StartExecution failure", func(t *testing.T) {
@@ -215,9 +216,9 @@ func TestCreateWorkflow(t *testing.T) {
 		assert.IsType(t, awsError, err)
 		assert.Equal(t, "test", err.(awserr.Error).Code()) // ensure this error came from sfn api
 
-		pendingIDs, err := c.store.GetPendingWorkflowIDs()
-		assert.Equal(t, 0, len(pendingIDs)) // new workflow not created
-
+		// TODO: Verify it's pending in the queue
+		//pendingIDs, err := c.store.GetPendingWorkflowIDs()
+		//assert.Equal(t, 0, len(pendingIDs)) // new workflow not created
 	})
 }
 

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -837,7 +837,7 @@ func newSFNManagerTestController(t *testing.T) *sfnManagerTestController {
 	require.NoError(t, store.SaveWorkflowDefinition(*workflowDefinition))
 
 	return &sfnManagerTestController{
-		manager:            NewSFNWorkflowManager(mockSFNAPI, mockSQSAPI, store, "", "", ""),
+		manager:            NewSFNWorkflowManager(mockSFNAPI, mockSQSAPI, store, "", "", "", ""),
 		mockController:     mockController,
 		mockSFNAPI:         mockSFNAPI,
 		mockSQSAPI:         mockSQSAPI,

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -21,6 +21,16 @@ routes:
       dimensions: ["workflow-id", "execution-id"]
       stat_type: "counter"
 
+  update-loop-lag-alert:
+    matchers:
+      title: ["pending-workflow-update-lag"]
+    output:
+      type: "alerts"
+      series: "workflow-manager.update-loop-lag-seconds"
+      value_field: "update-loop-lag-seconds"
+      stat_type: "gauge"
+      dimensions: []
+
   aws-sdk-go-counter:
     matchers:
       title: ["aws-sdk-go-counter"]

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -21,16 +21,6 @@ routes:
       dimensions: ["workflow-id", "execution-id"]
       stat_type: "counter"
 
-  update-loop-lag-alert:
-    matchers:
-      title: ["pending-workflows-locked"]
-    output:
-      type: "alerts"
-      series: "workflow-manager.update-loop-lag-seconds"
-      value_field: "update-loop-lag-seconds"
-      stat_type: "gauge"
-      dimensions: []
-
   aws-sdk-go-counter:
     matchers:
       title: ["aws-sdk-go-counter"]

--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -7,7 +7,8 @@ env:
   - AWS_SFN_REGION
   - AWS_SFN_ROLE_ARN
   - AWS_SFN_ACCOUNT_ID
-  #- AWS_SQS_REGION # TODO
+  - AWS_SQS_REGION
+  - AWS_SQS_URL 
 resources:
   cpu: 0.4
   soft_mem_limit: 0.15

--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -7,11 +7,17 @@ env:
   - AWS_SFN_REGION
   - AWS_SFN_ROLE_ARN
   - AWS_SFN_ACCOUNT_ID
+  #- AWS_SQS_REGION # TODO
 resources:
   cpu: 0.4
   soft_mem_limit: 0.15
   max_mem: 0.3
 aws:
+  sqs:
+    read:
+    - workflow-manager-update-loop
+    write:
+    - workflow-manager-update-loop
   custom: true
 expose:
 - name: default

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -262,34 +262,3 @@ func (b byLastUpdatedTime) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b byLastUpdatedTime) Less(i, j int) bool {
 	return time.Time(b[i].LastUpdated).Before(time.Time(b[j].LastUpdated))
 }
-
-func (s MemoryStore) GetPendingWorkflowIDs() ([]string, error) {
-	var pendingWorkflows []models.Workflow
-	for _, wf := range s.workflows {
-		if !(wf.Status == models.WorkflowStatusQueued || wf.Status == models.WorkflowStatusRunning) {
-			continue
-		}
-		wfcopy := wf // don't store loop variables
-		pendingWorkflows = append(pendingWorkflows, wfcopy)
-	}
-	sort.Sort(byLastUpdatedTime(pendingWorkflows))
-	pendingWorkflowIDs := []string{}
-	for _, pendingWorkflow := range pendingWorkflows {
-		pendingWorkflowIDs = append(pendingWorkflowIDs, pendingWorkflow.ID)
-	}
-	return pendingWorkflowIDs, nil
-
-}
-
-func (s MemoryStore) LockWorkflow(id string) error {
-	if _, ok := s.workflowsLocked[id]; ok {
-		return store.ErrWorkflowLocked
-	}
-	s.workflowsLocked[id] = struct{}{}
-	return nil
-}
-
-func (s MemoryStore) UnlockWorkflow(id string) error {
-	delete(s.workflowsLocked, id)
-	return nil
-}

--- a/store/store.go
+++ b/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
@@ -25,13 +24,7 @@ type Store interface {
 	UpdateWorkflow(workflow models.Workflow) error
 	GetWorkflowByID(id string) (models.Workflow, error)
 	GetWorkflows(query *models.WorkflowQuery) ([]models.Workflow, string, error)
-	GetPendingWorkflowIDs() ([]string, error)
-	LockWorkflow(id string) error
-	UnlockWorkflow(id string) error
 }
-
-// ErrWorkflowLocked is returned from LockWorfklow in the case of the workflow already being locked.
-var ErrWorkflowLocked = errors.New("workflow already locked")
 
 type ConflictError struct {
 	name string


### PR DESCRIPTION
JIRA: https://clever.atlassian.net/browse/INFRA-2829

This replaces polling dynamodb for updates (lots of calls against DynamoDB: looking up workflows, locking, and updating workflows) with a queue-based approach (puts workflows to update in a queue, no need for locking).

See mini-spec for more details: https://docs.google.com/document/d/1ghjxiImZYRN2ub233okATn2hG1McKhFm9yvm1rL_kPw/edit?ts=5a99edca#

I've tested locally and seems to work smoothly.

Considerations:

- I want to improve unit testing a little more
- Would it be worth abstracting the queue further? Lots of folks have made small abstractions around SQS that would help minimize the need to pass around config like delay duration, queue URL, etc (example: https://github.com/h2ik/go-sqs-poller)

--

- [x] Update swagger.yml version (n/a)
- [x] Run "make generate" (n/a)
