### PR TITLE
don't save Jobs for very large workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For more information, see the [full schema definition](docs/definitions.md#workf
 ### Updating the Data Store at Clever
 
 - If you need to add an index to the DynamoDB store, update the DynamoDB configuration in through the `infra` repo in addition to making code changes in this repo. The list of indices can be verified in the AWS console.
+- The DynamoDB store ignores `Workflow.Jobs` in case the size of the Workflow > 400KB due to DynamoDB limits.
 
 ### Updating the API
 

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func getEnvVarOrDefault(envVarName, defaultIfEmpty string) string {
 
 func logSFNCounts(sfnCounter *sfncounter.SFN) {
 	ticker := time.NewTicker(30 * time.Second)
-	for _ = range ticker.C {
+	for range ticker.C {
 		executor.LogSFNCounts(sfnCounter.Counters())
 	}
 }

--- a/resources/workflows.go
+++ b/resources/workflows.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/go-openapi/strfmt"
+	"github.com/mohae/deepcopy"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -75,4 +76,12 @@ func WorkflowIsDone(wf *models.Workflow) bool {
 	return (wf.Status == models.WorkflowStatusCancelled ||
 		wf.Status == models.WorkflowStatusFailed ||
 		wf.Status == models.WorkflowStatusSucceeded)
+}
+
+// CopyWorkflow creates a copy of an existing Worflow including WorkflowID
+//
+// This is used to save sligtly different copies of Workflows in the store
+func CopyWorkflow(workflow models.Workflow) models.Workflow {
+	newWorkflow := deepcopy.Copy(workflow).(models.Workflow)
+	return newWorkflow
 }


### PR DESCRIPTION
- DynamoDB does not like items > 400KB. 

Therefore we can return a large workflow but not save it

Additional things we could do here:

- limit by number of jobs. This would mean we don't have to retry
- exit out of UpdateWorkflowDetail early for large workflows. We should have some kind of limit to prevent against Hubble reloading a large workflow too often, since it hits our AWS limits hard. 
- binary encode jobs array so that we can save jobs in ddb (I don't see a strong reason for this right now)