### PR TITLE
Bugfix when logging update loop lag

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -77,6 +77,8 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 		return "", err
 	}
 
+	logPendingWorkflowUpdateLag(wf)
+
 	err = wm.UpdateWorkflowSummary(&wf)
 	if err != nil {
 		return "", err
@@ -99,8 +101,6 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	if err != nil {
 		return "", err
 	}
-
-	logPendingWorkflowUpdateLag(wf)
 
 	return wfID, nil
 }


### PR DESCRIPTION
Previously it was logging the update loop lag *after* being updated 🤕 

This fixes it to computing the lag *before* running `UpdateWorkflowSummary`