### PR TITLE
Backoff in polling loop DynamoDB throughput error

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
@@ -10,6 +11,8 @@ import (
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 )
@@ -23,10 +26,20 @@ type WorkflowManager interface {
 	UpdateWorkflowHistory(workflow *models.Workflow) error
 }
 
+var backoffDuration = time.Second * 5
+var shouldBackoff = false
+var shouldBackoffOnce *sync.Once
+
 // PollForPendingWorkflowsAndUpdateStore polls an SQS queue for workflows needing an update.
 // It will stop polling when the context is done.
 func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManager, thestore store.Store, sqsapi sqsiface.SQSAPI, sqsQueueURL string) {
 	for {
+		if shouldBackoff {
+			time.Sleep(backoffDuration)
+		}
+		shouldBackoff = false
+		shouldBackoffOnce = &sync.Once{}
+
 		select {
 		case <-ctx.Done():
 			log.Info("poll-for-pending-workflows-done")
@@ -46,6 +59,15 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 				go func(m *sqs.Message) {
 					defer wg.Done()
 					if id, err := updatePendingWorkflow(ctx, m, wm, thestore, sqsapi, sqsQueueURL); err != nil {
+						// If we're seeing DynamoDB throttling, let's wait before running our next poll loop
+						if aerr, ok := err.(awserr.Error); ok {
+							switch aerr.Code() {
+							case dynamodb.ErrCodeProvisionedThroughputExceededException:
+								shouldBackoffOnce.Do(func() {
+									shouldBackoff = true
+								})
+							}
+						}
 						log.ErrorD("update-pending-workflow", logger.M{"id": id, "error": err.Error()})
 					} else {
 						log.InfoD("update-pending-workflow", logger.M{"id": id})

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -147,7 +147,6 @@ func (d DynamoDB) InitTables(setupWorkflowsTTL bool) error {
 		(ddbWorkflowSecondaryKeyWorkflowDefinitionCreatedAt{}.AttributeDefinitions()),
 		(ddbWorkflowSecondaryKeyDefinitionResolvedByUserCreatedAt{}.AttributeDefinitions()),
 		(ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}.AttributeDefinitions()),
-		(ddbWorkflowSecondaryKeyStatusLastUpdated{}.AttributeDefinitions()),
 	} {
 		workflowAttributeDefinitions = append(workflowAttributeDefinitions, ads...)
 	}
@@ -180,17 +179,6 @@ func (d DynamoDB) InitTables(setupWorkflowsTTL bool) error {
 			{
 				IndexName: aws.String(ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}.Name()),
 				KeySchema: ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}.KeySchema(),
-				Projection: &dynamodb.Projection{
-					ProjectionType: aws.String(dynamodb.ProjectionTypeAll),
-				},
-				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-					ReadCapacityUnits:  aws.Int64(1),
-					WriteCapacityUnits: aws.Int64(1),
-				},
-			},
-			{
-				IndexName: aws.String(ddbWorkflowSecondaryKeyStatusLastUpdated{}.Name()),
-				KeySchema: ddbWorkflowSecondaryKeyStatusLastUpdated{}.KeySchema(),
 				Projection: &dynamodb.Projection{
 					ProjectionType: aws.String(dynamodb.ProjectionTypeAll),
 				},


### PR DESCRIPTION
In the case that many jobs are submitting at once, the SQS approach can lead to increased load on DynamoDB.

To help mitigate this, let's backoff in our polling loop if we start to see DynamoDB throughput errors.

--

This change also removes references to a now unused dynamodb GSI 14c2bc0