### PR TITLE
Remove `queued` workflow status

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -312,7 +312,7 @@
 
 <a name="workflowstatus"></a>
 ### WorkflowStatus
-*Type* : enum (queued, running, failed, succeeded, cancelled)
+*Type* : enum (running, failed, succeeded, cancelled)
 
 
 <a name="workflowsummary"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,3 +17,6 @@ Orchestrator for AWS Step Functions
 ### Produces
 
 * `application/json`
+
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.0
+*Version* : 0.9.1
 
 
 ### URI scheme

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -249,7 +249,7 @@ GET /workflows
 |**Query**|**oldestFirst**  <br>*optional*||boolean||
 |**Query**|**pageToken**  <br>*optional*||string||
 |**Query**|**resolvedByUser**  <br>*optional*|A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.|boolean||
-|**Query**|**status**  <br>*optional*|The status of the workflow (queued, running, etc.). Cannot be sent in the same request as the resolvedByUser parameter.|string||
+|**Query**|**status**  <br>*optional*|The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.|string||
 |**Query**|**summaryOnly**  <br>*optional*|Limits workflow data to the bare minimum - omits the full workflow definition and job data.|boolean|`"false"`|
 |**Query**|**workflowDefinitionName**  <br>*required*||string||
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -249,7 +249,7 @@ GET /workflows
 |**Query**|**oldestFirst**  <br>*optional*||boolean||
 |**Query**|**pageToken**  <br>*optional*||string||
 |**Query**|**resolvedByUser**  <br>*optional*|A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.|boolean||
-|**Query**|**status**  <br>*optional*|The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.|string||
+|**Query**|**status**  <br>*optional*|The status of the workflow. Cannot be sent in the same request as the resolvedByUser parameter.|enum (running, failed, cancelled, succeeded)||
 |**Query**|**summaryOnly**  <br>*optional*|Limits workflow data to the bare minimum - omits the full workflow definition and job data.|boolean|`"false"`|
 |**Query**|**workflowDefinitionName**  <br>*required*||string||
 

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -335,7 +335,7 @@ func sfnStatusToWorkflowStatus(sfnStatus string) models.WorkflowStatus {
 	case sfn.ExecutionStatusAborted:
 		return models.WorkflowStatusCancelled
 	default:
-		return models.WorkflowStatusQueued // this should never happen, since all cases are covered above
+		return models.WorkflowStatusRunning // this should never happen, since all cases are covered above
 	}
 }
 

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -328,7 +328,7 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
@@ -377,7 +377,7 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
@@ -423,7 +423,7 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
@@ -501,7 +501,7 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	executionOutput := `{"output": true}`
@@ -563,7 +563,7 @@ func TestUpdateWorkflowStatusJobCancelled(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	workflow.StatusReason = "cancelled by user"
 	c.saveWorkflow(ctx, t, workflow)
 
@@ -607,7 +607,7 @@ func TestUpdateWorkflowStatusWorkflowCancelledAfterJobSucceeded(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	workflow.StatusReason = "cancelled by user"
 	c.saveWorkflow(ctx, t, workflow)
 
@@ -652,7 +652,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundRetry(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	executionOutput := `{"output": true}`
@@ -690,7 +690,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundRetry(t *testing.T) {
 		})
 
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
-	assert.Equal(t, models.WorkflowStatusQueued, workflow.Status)
+	assert.Equal(t, models.WorkflowStatusRunning, workflow.Status)
 	require.Len(t, workflow.Jobs, 0)
 
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
@@ -709,7 +709,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundStopRetry(t *testing.T) {
 	defer c.tearDown()
 
 	workflow := c.newWorkflow()
-	workflow.Status = models.WorkflowStatusQueued
+	workflow.Status = models.WorkflowStatusRunning
 	c.saveWorkflow(ctx, t, workflow)
 
 	sfnExecutionARN := c.manager.executionARN(workflow, c.workflowDefinition)
@@ -724,7 +724,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundStopRetry(t *testing.T) {
 		Times(2)
 
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
-	assert.Equal(t, models.WorkflowStatusQueued, workflow.Status)
+	assert.Equal(t, models.WorkflowStatusRunning, workflow.Status)
 	require.Len(t, workflow.Jobs, 0)
 	time.Sleep(durationToRetryDescribeExecutions)
 

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -305,6 +305,12 @@ func (i GetWorkflowsInput) Validate() error {
 		}
 	}
 
+	if i.Status != nil {
+		if err := validate.Enum("status", "query", *i.Status, []interface{}{"running", "failed", "cancelled", "succeeded"}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/gen-go/models/workflow_status.go
+++ b/gen-go/models/workflow_status.go
@@ -19,8 +19,6 @@ import (
 type WorkflowStatus string
 
 const (
-	// WorkflowStatusQueued captures enum value "queued"
-	WorkflowStatusQueued WorkflowStatus = "queued"
 	// WorkflowStatusRunning captures enum value "running"
 	WorkflowStatusRunning WorkflowStatus = "running"
 	// WorkflowStatusFailed captures enum value "failed"
@@ -36,7 +34,7 @@ var workflowStatusEnum []interface{}
 
 func init() {
 	var res []WorkflowStatus
-	if err := json.Unmarshal([]byte(`["queued","running","failed","succeeded","cancelled"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["running","failed","succeeded","cancelled"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -298,7 +298,7 @@ Get the latest versions of all available WorkflowDefinitions
 | [params.limit] | <code>number</code> | <code>10</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |  |
 | [params.pageToken] | <code>string</code> |  |  |
-| [params.status] | <code>string</code> |  | The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
+| [params.status] | <code>string</code> |  | The status of the workflow. Cannot be sent in the same request as the resolvedByUser parameter. |
 | [params.resolvedByUser] | <code>boolean</code> |  | A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter. |
 | [params.summaryOnly] | <code>boolean</code> |  | Limits workflow data to the bare minimum - omits the full workflow definition and job data. |
 | params.workflowDefinitionName | <code>string</code> |  |  |
@@ -320,7 +320,7 @@ Get the latest versions of all available WorkflowDefinitions
 | [params.limit] | <code>number</code> | <code>10</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |  |
 | [params.pageToken] | <code>string</code> |  |  |
-| [params.status] | <code>string</code> |  | The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
+| [params.status] | <code>string</code> |  | The status of the workflow. Cannot be sent in the same request as the resolvedByUser parameter. |
 | [params.resolvedByUser] | <code>boolean</code> |  | A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter. |
 | [params.summaryOnly] | <code>boolean</code> |  | Limits workflow data to the bare minimum - omits the full workflow definition and job data. |
 | params.workflowDefinitionName | <code>string</code> |  |  |

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -298,7 +298,7 @@ Get the latest versions of all available WorkflowDefinitions
 | [params.limit] | <code>number</code> | <code>10</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |  |
 | [params.pageToken] | <code>string</code> |  |  |
-| [params.status] | <code>string</code> |  | The status of the workflow (queued, running, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
+| [params.status] | <code>string</code> |  | The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
 | [params.resolvedByUser] | <code>boolean</code> |  | A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter. |
 | [params.summaryOnly] | <code>boolean</code> |  | Limits workflow data to the bare minimum - omits the full workflow definition and job data. |
 | params.workflowDefinitionName | <code>string</code> |  |  |
@@ -320,7 +320,7 @@ Get the latest versions of all available WorkflowDefinitions
 | [params.limit] | <code>number</code> | <code>10</code> | Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000. |
 | [params.oldestFirst] | <code>boolean</code> |  |  |
 | [params.pageToken] | <code>string</code> |  |  |
-| [params.status] | <code>string</code> |  | The status of the workflow (queued, running, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
+| [params.status] | <code>string</code> |  | The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter. |
 | [params.resolvedByUser] | <code>boolean</code> |  | A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter. |
 | [params.summaryOnly] | <code>boolean</code> |  | Limits workflow data to the bare minimum - omits the full workflow definition and job data. |
 | params.workflowDefinitionName | <code>string</code> |  |  |

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -1466,7 +1466,7 @@ class WorkflowManager {
    * @param {number} [params.limit=10] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
-   * @param {string} [params.status] - The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
+   * @param {string} [params.status] - The status of the workflow. Cannot be sent in the same request as the resolvedByUser parameter.
    * @param {boolean} [params.resolvedByUser] - A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.
    * @param {boolean} [params.summaryOnly] - Limits workflow data to the bare minimum - omits the full workflow definition and job data.
    * @param {string} params.workflowDefinitionName
@@ -1620,7 +1620,7 @@ class WorkflowManager {
    * @param {number} [params.limit=10] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
-   * @param {string} [params.status] - The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
+   * @param {string} [params.status] - The status of the workflow. Cannot be sent in the same request as the resolvedByUser parameter.
    * @param {boolean} [params.resolvedByUser] - A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.
    * @param {boolean} [params.summaryOnly] - Limits workflow data to the bare minimum - omits the full workflow definition and job data.
    * @param {string} params.workflowDefinitionName

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -1466,7 +1466,7 @@ class WorkflowManager {
    * @param {number} [params.limit=10] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
-   * @param {string} [params.status] - The status of the workflow (queued, running, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
+   * @param {string} [params.status] - The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
    * @param {boolean} [params.resolvedByUser] - A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.
    * @param {boolean} [params.summaryOnly] - Limits workflow data to the bare minimum - omits the full workflow definition and job data.
    * @param {string} params.workflowDefinitionName
@@ -1620,7 +1620,7 @@ class WorkflowManager {
    * @param {number} [params.limit=10] - Maximum number of workflows to return. Defaults to 10. Restricted to a max of 10,000.
    * @param {boolean} [params.oldestFirst]
    * @param {string} [params.pageToken]
-   * @param {string} [params.status] - The status of the workflow (queued, running, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
+   * @param {string} [params.status] - The status of the workflow (running, failed, etc.). Cannot be sent in the same request as the resolvedByUser parameter.
    * @param {boolean} [params.resolvedByUser] - A flag that indicates whether the workflow has been marked resolved by a user. Cannot be sent in the same request as the status parameter.
    * @param {boolean} [params.summaryOnly] - Limits workflow data to the bare minimum - omits the full workflow definition and job data.
    * @param {string} params.workflowDefinitionName

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/resources/workflows.go
+++ b/resources/workflows.go
@@ -17,7 +17,7 @@ func NewWorkflow(wfd *models.WorkflowDefinition, input string, namespace string,
 			CreatedAt:          strfmt.DateTime(time.Now()),
 			LastUpdated:        strfmt.DateTime(time.Now()),
 			WorkflowDefinition: wfd,
-			Status:             models.WorkflowStatusQueued,
+			Status:             models.WorkflowStatusRunning,
 			Namespace:          namespace,
 			Queue:              queue,
 			Input:              input,
@@ -51,8 +51,6 @@ func WorkflowStatusToInt(status models.WorkflowStatus) int {
 	case models.WorkflowStatusFailed:
 		return 1
 	// states in path to completion return zero
-	case models.WorkflowStatusQueued:
-		return 0
 	case models.WorkflowStatusRunning:
 		return 0
 	case models.WorkflowStatusSucceeded:

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -266,7 +266,7 @@ func DeleteWorkflow(s store.Store, t *testing.T) func(t *testing.T) {
 
 		savedWorkflow, err := s.GetWorkflowByID(ctx, workflow.ID)
 		require.Nil(t, err)
-		require.Equal(t, savedWorkflow.Status, models.WorkflowStatusQueued)
+		require.Equal(t, savedWorkflow.Status, models.WorkflowStatusRunning)
 
 		require.Nil(t, s.DeleteWorkflowByID(ctx, workflow.ID))
 
@@ -294,7 +294,7 @@ func GetWorkflowByID(s store.Store, t *testing.T) func(t *testing.T) {
 				ID:                 workflow.ID,
 				WorkflowDefinition: wf,
 				Input:              `["input"]`,
-				Status:             models.WorkflowStatusQueued,
+				Status:             models.WorkflowStatusRunning,
 				Namespace:          "namespace",
 				Queue:              "queue",
 				Tags:               tags,

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.0
+  version: 0.9.1
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -172,10 +172,12 @@ paths:
           type: string
         - name: status
           description:
-            The status of the workflow (queued, running, etc.). Cannot be sent in the
-             same request as the resolvedByUser parameter.
+            The status of the workflow. Cannot be sent in the same request as
+            the resolvedByUser parameter.
           in: query
           type: string
+          # Note: These are the same values as in "#/definitions/WorkflowStatus"
+          enum: [running, failed, cancelled, succeeded]
         - name: resolvedByUser
           in: query
           type: boolean

--- a/swagger.yml
+++ b/swagger.yml
@@ -468,7 +468,6 @@ definitions:
   WorkflowStatus:
     type: string
     enum:
-      - "queued"
       - "running"
       - "failed"
       - "succeeded"


### PR DESCRIPTION
Currently, a "queued" workflow means something more like "initialized". We have created a Workflow but have not yet sync'd its status from Step Functions.

There's not a huge amount of value in having a separate state for this. Some users have found it confusing.  In the short-run, might we just removed "queued"?

There's one specific loss in resolution here. Sometimes "queued" helps us catch wedged workflows. It's possible for us to fail to create an execution in Step Functions and also fail to cleanup the workflow. Having it in a "queued" state vs "running" helps us notice that this workflow is broken.

- [x] Update swagger.yml version
- [x] Run "make generate"

--

In the long-run, we might prefer adding more Workflow Statuses to give us more insight.

1. "initialized" -- we've submitted the workflow to Step Functions, but haven't yet sync'd any info back to Workflow Manager
2. "queued" - the Step Function is "running", but its first task is "queued"... Basically, there are no workers yet processing the workflow. From a user's perspective, this means that queue size == backlog ... It may indicate that more workers need to be run in order to catch up.
3. "running" - the Step Function is "running" and its first task is "running" or "completed".

This approach would require us to fetch the first page of tasks from each workflow, so would require more API calls to Step Functions.
