### PR TITLE
use mock from master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -95,12 +95,6 @@
   revision = "b8f31a59085e69dd2678cf51840db2ac625cb741"
 
 [[projects]]
-  name = "github.com/ghodss/yaml"
-  packages = ["."]
-  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/go-errors/errors"
   packages = ["."]
   revision = "8fa88b06e5974e97fbf9899a7f86a344bfd1f105"
@@ -177,14 +171,14 @@
   revision = "117892bf1866fbaa2318c03e50e40564c8845457"
 
 [[projects]]
+  branch = "master"
   name = "github.com/golang/mock"
   packages = [
     "gomock",
     "mockgen",
     "mockgen/model"
   ]
-  revision = "13f360950a79f5864a972c786a10a50e44b69541"
-  version = "v1.0.0"
+  revision = "8b2eeeb0ca5f56c78bec5efde9c4a21d9201126c"
 
 [[projects]]
   branch = "master"
@@ -419,6 +413,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eddae18698c68de970b4eb57f3b1b05ee7c1eabc526143c52022f4b550e9c72a"
+  inputs-digest = "2246511c3a288080d7aa8b28623fcc03115313420e50ea95f3cba5633b669ea7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "github.com/golang/mock"
-  version = "1.0.0"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.0
+*Version* : 0.9.1
 
 
 ### URI scheme

--- a/gen-go/server/db/dynamodb/dynamodb_test.go
+++ b/gen-go/server/db/dynamodb/dynamodb_test.go
@@ -1,14 +1,13 @@
 package dynamodb
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Clever/workflow-manager/gen-go/server/db"
 	"github.com/Clever/workflow-manager/gen-go/server/db/tests"
@@ -23,16 +22,19 @@ func TestDynamoDBStore(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmd := exec.CommandContext(testCtx, "./dynamodb-local.sh")
-	var ddbLocalOutput bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &ddbLocalOutput)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &ddbLocalOutput)
+	ddbLocalOutputReader, ddbLocalOutputWriter := io.Pipe()
+	cmd.Stdout = io.MultiWriter(os.Stdout, ddbLocalOutputWriter)
+	cmd.Stderr = io.MultiWriter(os.Stderr, ddbLocalOutputWriter)
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
 
 	// wait for dynamodb local to output the correct startup log
-	for !strings.Contains(ddbLocalOutput.String(), "Initializing DynamoDB Local with the following configuration") {
-		time.Sleep(1 * time.Second)
+	scanner := bufio.NewScanner(ddbLocalOutputReader)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "Initializing DynamoDB Local with the following configuration") {
+			break
+		}
 	}
 
 	dynamoDBAPI := dynamodb.New(session.Must(session.NewSessionWithOptions(session.Options{

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.0
+  version: 0.9.1
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
Since it's causing some trouble with HM dependency vendoring. I ran into a problem before where not having the latest mock version would error, but I can't get it to reproduce now:
https://circleci.com/gh/Clever/il-user-service/90?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Since `mock` is a dev dependency, it should not affect production to use the master build.

I think it was initially locked because of some HM vendoring problems (https://github.com/Clever/workflow-manager/pull/117/files) but I was able to successfully run `make install_deps` after vendoring this specific branch onto HM, so this should work.

- [ ] Update swagger.yml version
- [ ] Run "make generate"
