### PR TITLE
[INFRA-3134] workflow-manager is wag so needs node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/workflow-manager
     docker:
-    - image: circleci/golang:1.10-node
+    - image: circleci/golang@sha256:dbcd25bb717ed97b229311388efd6a1a3e1841da08899f40b34632ebb58915ed # circleci/golang:1.10-node
     steps:
     - checkout
     - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,6 @@ jobs:
     - run:
         name: Clone ci-scripts
         command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-    - run:
-        name: Set up npm
-        command: |
-            sudo apt-get -y update
-            sudo npm install -g npm@latest
     - run: make install_deps
     - run: make build
     - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/workflow-manager
     docker:
-    - image: circleci/golang:1.10
+    - image: circleci/golang:1.10-node
     steps:
     - checkout
     - setup_remote_docker
@@ -16,23 +16,20 @@ jobs:
     - run:
         name: Clone ci-scripts
         command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+    - run:
+        name: Set up npm
+        command: |
+            sudo apt-get -y update
+            sudo npm install -g npm@latest
     - run: make install_deps
     - run: make build
     - run: make test
-    - run: |
-        $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - run: |
-        $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
-    - run: |
-        if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev no-confirm-deploy;
+    - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
+    - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev no-confirm-deploy;
         fi;
-    - run: |
-        if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy;
         fi;
-    - run: |
-        if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN gen-js/; fi;
-    - run:
-        name: Publish GitHub release
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then cat ./swagger.yml | grep "^  version:" | cut -d":" -f2 | tr -d " " > ./VERSION; fi;
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN gen-js/; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then cat ./swagger.yml | grep "^  version:" | cut -d":" -f2 | tr -d " " > ./VERSION; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN; fi;


### PR DESCRIPTION
Since `workflow-manager` is a WAG service, this PR:
- uses the version of the base docker image with node (by SHA, to lock in exact versions)
- unrelated, remvoes some uneccessary line breaks

