### PR TITLE
Rate limit is increased; Pull more messages

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -44,7 +44,7 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 			return
 		default:
 			out, err := sqsapi.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
-				MaxNumberOfMessages: aws.Int64(10),
+				MaxNumberOfMessages: aws.Int64(15),
 				QueueUrl:            aws.String(sqsQueueURL),
 			})
 			if err != nil {


### PR DESCRIPTION
We've just got the bucket size increased for `DescribeExecution` and therefore we should be able to handle more messages per batch. Increasing the batch size should also allow us to handle more active executions with a lower workflow-manager container count. This is helpful since we don't have much CPU usage per container. 

Ideally long term we want to be able to control the rate via environment variable. 