### PR TITLE
Revert "Rate limit is increased; Pull more messages"

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -44,7 +44,7 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 			return
 		default:
 			out, err := sqsapi.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
-				MaxNumberOfMessages: aws.Int64(15),
+				MaxNumberOfMessages: aws.Int64(10),
 				QueueUrl:            aws.String(sqsQueueURL),
 			})
 			if err != nil {


### PR DESCRIPTION
Reverts Clever/workflow-manager#144

This did not work since `ReceiveMessage` has a max value of 10

> The maximum number of messages to return. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10. Default: 1. - [docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)

