### PR TITLE
Fix 404 crash

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  branch = "master"
   name = "github.com/Clever/aws-sdk-go-counter"
   packages = ["counter/sfncounter"]
   revision = "6cdff7b1a4b593eafacf9c31ece8a830136f4125"
@@ -10,18 +9,20 @@
 [[projects]]
   name = "github.com/Clever/discovery-go"
   packages = ["."]
-  revision = "2e485eaaf026d527548740ceff178c8859fcaa07"
+  revision = "b2114f3bdf1c55f030cf6d6d457478ccb18b9e9c"
+  version = "v1.7.1"
 
 [[projects]]
   name = "github.com/Clever/go-process-metrics"
   packages = ["metrics"]
-  revision = "5944a49b5051ebcc10feb08724689740b4eefa28"
+  revision = "86b8beeca7d3dc0ce41b3d29debfc47819eeb4b1"
+  version = "0.1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  revision = "fd18e053af8a4ff11039269006e8037ff374ce0e"
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -37,12 +38,13 @@
     "hystrix/metric_collector",
     "hystrix/rolling"
   ]
-  revision = "f118cd938f786d24f46cc307981d8f63b7951020"
+  revision = "fa1af6a1f4f56e0e50d427fe901cd604d8c6fb8a"
 
 [[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  revision = "ddb193b4c7bfa1d1c1923ae05a1ee8fb0cd45cf3"
+  revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
+  version = "v9"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -57,13 +59,16 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/json/jsonutil",
@@ -81,94 +86,95 @@
     "service/sqs/sqsiface",
     "service/sts"
   ]
-  revision = "63324a33d7e42a386c04d4daec764a3de243492e"
-  version = "v1.13.0"
+  revision = "cfcda8304585604aabf1f7f8f7ce67b55029d0ca"
+  version = "v1.15.47"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/donovanhide/eventsource"
   packages = ["."]
-  revision = "b8f31a59085e69dd2678cf51840db2ac625cb741"
+  revision = "3ed64d21fb0b6bd8b49bcfec08f3004daee8723d"
 
 [[projects]]
   name = "github.com/go-errors/errors"
   packages = ["."]
-  revision = "8fa88b06e5974e97fbf9899a7f86a344bfd1f105"
+  revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "f280b3ba517bf5fc98922624f21fb0e7a92adaec"
-  version = "v1.30.3"
+  revision = "7b294651033cd7d9e7f0d9ffa1b75ed1e198e737"
+  version = "v1.38.3"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/analysis"
-  packages = ["."]
-  revision = "f59a71f0ece6f9dfb438be7f45148f006cbad88e"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "7c1bef8f6d9fa6148ce0d8a0ebf5339a084a6639"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/errors"
   packages = ["."]
-  revision = "7bcb96a367bac6b76e6e42fa84155bb5581dcff8"
+  revision = "b2b2befaf267d082d779bcef52d682a47c779517"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  revision = "779f45308c19820f1a69e9a4cd965f496e0da10f"
+  revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  revision = "36d33bfe519efae5632669801b180bf1a245da3b"
+  revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/loads"
   packages = ["."]
-  revision = "c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820"
+  revision = "2a2b323bab96e6b1fdee110e57d959322446e9c9"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/runtime"
   packages = ["."]
-  revision = "62281b694b396a17fe3e4313ee8b0ca2c3cca719"
+  revision = "9a3091f566c0811ef4d54b535179bc0fc484a11f"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "9acd88844bc186c3ec7f318cd3d56f1114b4ab99"
+  revision = "384415f06ee238aae1df5caad877de6ceac3a5c4"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  revision = "610b6cacdcde6852f4de68998bd20ce1dac85b22"
+  revision = "913ee058e387ac83a67e2d9f13acecdcd5769fc6"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
+  revision = "becd2f08beafcca035645a8a101e0e3e18140458"
+  version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "180bba53b98899f743a112e568bed9e2ef31aa20"
-
-[[projects]]
-  name = "github.com/gogo/protobuf"
-  packages = ["proto"]
-  revision = "117892bf1866fbaa2318c03e50e40564c8845457"
+  revision = "7c1911976134d3a24d0c03127505163c9f16aa3b"
+  version = "0.16.0"
 
 [[projects]]
   branch = "master"
@@ -178,39 +184,41 @@
     "mockgen",
     "mockgen/model"
   ]
-  revision = "8b2eeeb0ca5f56c78bec5efde9c4a21d9201126c"
+  revision = "600781dde9cca80734169b9e969d9054ccc57937"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "757bef944d0f21880861c2dd9c871ca543023cba"
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru"
   ]
-  revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -229,40 +237,33 @@
     ".",
     "collectorpb",
     "lightstep_thrift",
-    "thrift_0_9_2/lib/go/thrift",
-    "thrift_rpc"
+    "lightsteppb",
+    "thrift_0_9_2/lib/go/thrift"
   ]
-  revision = "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce"
+  revision = "ee5c8997bd8d23c5086ee174c8bc698c3edff871"
+  version = "v0.15.4"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
     "jwriter"
   ]
-  revision = "4d347d79dea0067c945f374f990601decb08abb5"
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+  revision = "fe40af7a9c397fa3ddba203c38a5042c5d0475ad"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/mohae/deepcopy"
   packages = ["."]
   revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
-
-[[projects]]
-  name = "github.com/opentracing/basictracer-go"
-  packages = [
-    ".",
-    "wire"
-  ]
-  revision = "1b32af207119a14b1b231d451df3ed04a72efebf"
-  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -277,13 +278,14 @@
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -291,40 +293,47 @@
     "assert",
     "require"
   ]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
-  revision = "6fe8760cad3569743d51ddbb243b26f8456742dc"
+  revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonreference"
   packages = ["."]
-  revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
+  revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
+
+[[projects]]
+  name = "github.com/xeipuuv/gojsonschema"
+  packages = ["."]
+  revision = "da425ebb7609ba06a0f395fc8a254d1c303364a0"
+  version = "v1.0"
 
 [[projects]]
   branch = "master"
-  name = "github.com/xeipuuv/gojsonschema"
-  packages = ["."]
-  revision = "212d8a0df7acfab8bdd190a7a69f0ab7376edcc8"
-
-[[projects]]
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "lex/httplex",
     "trace"
   ]
-  revision = "c73622c77280266305273cb545f54516ced95b93"
+  revision = "f5e5bdd778241bfefa8627f7124c39cd6ad8d74f"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "af653ce8b74f808d092db8ca9741fbb63d2a469d"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -345,25 +354,37 @@
     "unicode/rangetable",
     "width"
   ]
-  revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/rpc/status"]
-  revision = "f676e0f3ac6395ff1a529ae59a6670878a8371a6"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/rpc/status"
+  ]
+  revision = "c7e5094acea1ca1b899e2259d80a6b0f882f81f8"
 
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
+    "balancer/base",
     "balancer/roundrobin",
     "codes",
     "connectivity",
     "credentials",
-    "grpclb/grpc_lb_v1/messages",
+    "encoding",
+    "encoding/proto",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -373,10 +394,10 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
-    "transport"
+    "tap"
   ]
-  revision = "c91118c8fa0e1821c8fb860e15aaae5e6acb1add"
+  revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
+  version = "v1.15.0"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
@@ -386,8 +407,8 @@
     "middleware",
     "router"
   ]
-  revision = "e1e6fd8184162847c1123645e7058347a2fd3959"
-  version = "v6.10.0"
+  revision = "e03ef3cfc5769be7e502dde84ef35d9d726aef6e"
+  version = "v6.13.0"
 
 [[projects]]
   branch = "v2"
@@ -396,7 +417,7 @@
     "bson",
     "internal/json"
   ]
-  revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
+  revision = "9856a29383ce1c59f308dd1cf0363a79b5bef6b5"
 
 [[projects]]
   name = "gopkg.in/tylerb/graceful.v1"
@@ -405,14 +426,14 @@
   version = "v1.2.15"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4a6a7aa8768879c62ab2784108437e5c2ff542faae019635c0df97000861b975"
+  inputs-digest = "c35ad254cca1e7082af83c4c625683a1fb6f1fdbaa34932ec254cb6b59c722e4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,6 +2,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "github.com/Clever/aws-sdk-go-counter"
+  revision = "6cdff7b1a4b593eafacf9c31ece8a830136f4125"
 
 [[constraint]]
   name = "github.com/Clever/discovery-go"
@@ -12,7 +13,7 @@ required = ["github.com/golang/mock/mockgen"]
 [[constraint]]
   name = "github.com/afex/hystrix-go"
 
-[[constraint]]
+[[require]]
   name = "github.com/aws/aws-sdk-go"
   version = "1.13.0"
 
@@ -67,7 +68,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  version = "6.10.0"
+  version = "^6.10.0"
 
 [[constraint]]
   name = "gopkg.in/tylerb/graceful.v1"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKGS := $(shell go list ./... | grep -v /vendor | grep -v /gen-go | grep -v /wor
 PKGS := $(PKGS) $(PKG)/gen-go/server/db/dynamodb
 
 # Currently using old version because ```WAG_VERSION := latest``` is broken on this repo
-WAG_VERSION := v1.7.2
+WAG_VERSION := latest
 
 $(eval $(call golang-version-check,1.10))
 

--- a/executor/log_helpers.go
+++ b/executor/log_helpers.go
@@ -41,7 +41,7 @@ func logWorkflowStatusChange(workflow *models.Workflow, previousStatus models.Wo
 }
 
 func logPendingWorkflowUpdateLag(wf models.Workflow) {
-	log.InfoD("pending-workflow-update-lag", logger.M{
+	log.TraceD("pending-workflow-update-lag", logger.M{
 		"id": wf.ID,
 		"update-loop-lag-seconds": int(time.Now().Sub(time.Time(wf.LastUpdated)) / time.Second),
 	})
@@ -49,6 +49,8 @@ func logPendingWorkflowUpdateLag(wf models.Workflow) {
 
 func LogSFNCounts(sfnCounters map[string]int64) {
 	for k, v := range sfnCounters {
-		log.InfoD("aws-sdk-go-counter", logger.M{"app": "workflow-manager", "value": v, "aws-operation": k, "aws-service": "sfn"})
+		log.TraceD("aws-sdk-go-counter", logger.M{
+			"app": "workflow-manager", "value": v, "aws-operation": k, "aws-service": "sfn",
+		})
 	}
 }

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -142,6 +142,11 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
 }
 
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
+}
+
 // HealthCheck makes a GET request to /_health
 // Checks if the service is healthy
 // 200: nil
@@ -165,6 +170,8 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 
 func (c *WagClient) doHealthCheckRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -266,6 +273,8 @@ func (c *WagClient) PostStateResource(ctx context.Context, i *models.NewStateRes
 func (c *WagClient) doPostStateResourceRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.StateResource, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -366,6 +375,8 @@ func (c *WagClient) DeleteStateResource(ctx context.Context, i *models.DeleteSta
 
 func (c *WagClient) doDeleteStateResourceRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -470,6 +481,8 @@ func (c *WagClient) GetStateResource(ctx context.Context, i *models.GetStateReso
 
 func (c *WagClient) doGetStateResourceRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.StateResource, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -590,6 +603,8 @@ func (c *WagClient) PutStateResource(ctx context.Context, i *models.PutStateReso
 func (c *WagClient) doPutStateResourceRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.StateResource, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -683,6 +698,8 @@ func (c *WagClient) GetWorkflowDefinitions(ctx context.Context) ([]models.Workfl
 
 func (c *WagClient) doGetWorkflowDefinitionsRequest(ctx context.Context, req *http.Request, headers map[string]string) ([]models.WorkflowDefinition, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -789,6 +806,8 @@ func (c *WagClient) NewWorkflowDefinition(ctx context.Context, i *models.NewWork
 func (c *WagClient) doNewWorkflowDefinitionRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.WorkflowDefinition, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -889,6 +908,8 @@ func (c *WagClient) GetWorkflowDefinitionVersionsByName(ctx context.Context, i *
 
 func (c *WagClient) doGetWorkflowDefinitionVersionsByNameRequest(ctx context.Context, req *http.Request, headers map[string]string) ([]models.WorkflowDefinition, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -1010,6 +1031,8 @@ func (c *WagClient) UpdateWorkflowDefinition(ctx context.Context, i *models.Upda
 func (c *WagClient) doUpdateWorkflowDefinitionRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.WorkflowDefinition, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -1118,6 +1141,8 @@ func (c *WagClient) GetWorkflowDefinitionByNameAndVersion(ctx context.Context, i
 
 func (c *WagClient) doGetWorkflowDefinitionByNameAndVersionRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.WorkflowDefinition, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -1314,6 +1339,8 @@ func (i *getWorkflowsIterImpl) Err() error {
 func (c *WagClient) doGetWorkflowsRequest(ctx context.Context, req *http.Request, headers map[string]string) ([]models.Workflow, string, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -1427,6 +1454,8 @@ func (c *WagClient) StartWorkflow(ctx context.Context, i *models.StartWorkflowRe
 
 func (c *WagClient) doStartWorkflowRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.Workflow, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -1548,6 +1577,8 @@ func (c *WagClient) CancelWorkflow(ctx context.Context, i *models.CancelWorkflow
 func (c *WagClient) doCancelWorkflowRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -1651,6 +1682,8 @@ func (c *WagClient) GetWorkflowByID(ctx context.Context, workflowID string) (*mo
 
 func (c *WagClient) doGetWorkflowByIDRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.Workflow, error) {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)
@@ -1772,6 +1805,8 @@ func (c *WagClient) ResumeWorkflowByID(ctx context.Context, i *models.ResumeWork
 func (c *WagClient) doResumeWorkflowByIDRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.Workflow, error) {
 	client := &http.Client{Transport: c.transport}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	for field, value := range headers {
 		req.Header.Set(field, value)
 	}
@@ -1881,6 +1916,8 @@ func (c *WagClient) ResolveWorkflowByID(ctx context.Context, workflowID string) 
 
 func (c *WagClient) doResolveWorkflowByIDRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
 	client := &http.Client{Transport: c.transport}
+
+	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
 		req.Header.Set(field, value)

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -127,8 +127,10 @@ type PutStateResourceInput struct {
 // requirements from the swagger yml file.
 func (i PutStateResourceInput) Validate() error {
 
-	if err := i.NewStateResource.Validate(nil); err != nil {
-		return err
+	if i.NewStateResource != nil {
+		if err := i.NewStateResource.Validate(nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -221,8 +223,10 @@ type UpdateWorkflowDefinitionInput struct {
 // requirements from the swagger yml file.
 func (i UpdateWorkflowDefinitionInput) Validate() error {
 
-	if err := i.NewWorkflowDefinitionRequest.Validate(nil); err != nil {
-		return err
+	if i.NewWorkflowDefinitionRequest != nil {
+		if err := i.NewWorkflowDefinitionRequest.Validate(nil); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -352,8 +356,10 @@ type CancelWorkflowInput struct {
 // requirements from the swagger yml file.
 func (i CancelWorkflowInput) Validate() error {
 
-	if err := i.Reason.Validate(nil); err != nil {
-		return err
+	if i.Reason != nil {
+		if err := i.Reason.Validate(nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -414,8 +420,10 @@ type ResumeWorkflowByIDInput struct {
 // requirements from the swagger yml file.
 func (i ResumeWorkflowByIDInput) Validate() error {
 
-	if err := i.Overrides.Validate(nil); err != nil {
-		return err
+	if i.Overrides != nil {
+		if err := i.Overrides.Validate(nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/gen-go/server/db/dynamodb/dynamodb.go
+++ b/gen-go/server/db/dynamodb/dynamodb.go
@@ -90,6 +90,11 @@ func (d DB) GetWorkflowDefinition(ctx context.Context, name string, version int6
 	return d.workflowDefinitionTable.getWorkflowDefinition(ctx, name, version)
 }
 
+// GetWorkflowDefinitionsByNameAndVersion retrieves a list of WorkflowDefinitions from the database.
+func (d DB) GetWorkflowDefinitionsByNameAndVersion(ctx context.Context, input db.GetWorkflowDefinitionsByNameAndVersionInput) ([]models.WorkflowDefinition, error) {
+	return d.workflowDefinitionTable.getWorkflowDefinitionsByNameAndVersion(ctx, input)
+}
+
 // DeleteWorkflowDefinition deletes a WorkflowDefinition from the database.
 func (d DB) DeleteWorkflowDefinition(ctx context.Context, name string, version int64) error {
 	return d.workflowDefinitionTable.deleteWorkflowDefinition(ctx, name, version)

--- a/gen-go/server/db/interface.go
+++ b/gen-go/server/db/interface.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
 )
@@ -15,8 +14,24 @@ type Interface interface {
 	SaveWorkflowDefinition(ctx context.Context, m models.WorkflowDefinition) error
 	// GetWorkflowDefinition retrieves a WorkflowDefinition from the database.
 	GetWorkflowDefinition(ctx context.Context, name string, version int64) (*models.WorkflowDefinition, error)
+	// GetWorkflowDefinitionsByNameAndVersion retrieves a list of WorkflowDefinitions from the database.
+	GetWorkflowDefinitionsByNameAndVersion(ctx context.Context, input GetWorkflowDefinitionsByNameAndVersionInput) ([]models.WorkflowDefinition, error)
 	// DeleteWorkflowDefinition deletes a WorkflowDefinition from the database.
 	DeleteWorkflowDefinition(ctx context.Context, name string, version int64) error
+}
+
+// Int64 returns a pointer to the int64 value passed in.
+func Int64(i int64) *int64 { return &i }
+
+// String returns a pointer to the string value passed in.
+func String(s string) *string { return &s }
+
+// GetWorkflowDefinitionsByNameAndVersionInput is the query input to GetWorkflowDefinitionsByNameAndVersion.
+type GetWorkflowDefinitionsByNameAndVersionInput struct {
+	Name                  string
+	VersionStartingAt     *int64
+	Descending            bool
+	DisableConsistentRead bool
 }
 
 // ErrWorkflowDefinitionNotFound is returned when the database fails to find a WorkflowDefinition.
@@ -29,7 +44,7 @@ var _ error = ErrWorkflowDefinitionNotFound{}
 
 // Error returns a description of the error.
 func (e ErrWorkflowDefinitionNotFound) Error() string {
-	return fmt.Sprintf("could not find WorkflowDefinition: %v", e)
+	return "could not find WorkflowDefinition"
 }
 
 // ErrWorkflowDefinitionAlreadyExists is returned when trying to overwrite a WorkflowDefinition.
@@ -42,5 +57,5 @@ var _ error = ErrWorkflowDefinitionAlreadyExists{}
 
 // Error returns a description of the error.
 func (e ErrWorkflowDefinitionAlreadyExists) Error() string {
-	return fmt.Sprintf("WorkflowDefinition already exists: %v", e)
+	return "WorkflowDefinition already exists"
 }

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -160,7 +160,9 @@ func (h handler) PostStateResourceHandler(ctx context.Context, w http.ResponseWr
 		return
 	}
 
-	err = input.Validate(nil)
+	if input != nil {
+		err = input.Validate(nil)
+	}
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
@@ -199,20 +201,22 @@ func (h handler) PostStateResourceHandler(ctx context.Context, w http.ResponseWr
 
 // newPostStateResourceInput takes in an http.Request an returns the input struct.
 func newPostStateResourceInput(r *http.Request) (*models.NewStateResource, error) {
-	var input models.NewStateResource
-
 	var err error
 	_ = err
 
 	data, err := ioutil.ReadAll(r.Body)
 
 	if len(data) > 0 {
+
+		var input models.NewStateResource
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&input); err != nil {
 			return nil, err
 		}
+		return &input, nil
+
 	}
 
-	return &input, nil
+	return nil, nil
 }
 
 // statusCodeForDeleteStateResource returns the status code corresponding to the returned
@@ -564,10 +568,12 @@ func newPutStateResourceInput(r *http.Request) (*models.PutStateResourceInput, e
 	data, err := ioutil.ReadAll(r.Body)
 
 	if len(data) > 0 {
+
 		input.NewStateResource = &models.NewStateResource{}
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.NewStateResource); err != nil {
 			return nil, err
 		}
+
 	}
 
 	return &input, nil
@@ -687,7 +693,9 @@ func (h handler) NewWorkflowDefinitionHandler(ctx context.Context, w http.Respon
 		return
 	}
 
-	err = input.Validate(nil)
+	if input != nil {
+		err = input.Validate(nil)
+	}
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
@@ -726,20 +734,22 @@ func (h handler) NewWorkflowDefinitionHandler(ctx context.Context, w http.Respon
 
 // newNewWorkflowDefinitionInput takes in an http.Request an returns the input struct.
 func newNewWorkflowDefinitionInput(r *http.Request) (*models.NewWorkflowDefinitionRequest, error) {
-	var input models.NewWorkflowDefinitionRequest
-
 	var err error
 	_ = err
 
 	data, err := ioutil.ReadAll(r.Body)
 
 	if len(data) > 0 {
+
+		var input models.NewWorkflowDefinitionRequest
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&input); err != nil {
 			return nil, err
 		}
+		return &input, nil
+
 	}
 
-	return &input, nil
+	return nil, nil
 }
 
 // statusCodeForGetWorkflowDefinitionVersionsByName returns the status code corresponding to the returned
@@ -961,10 +971,12 @@ func newUpdateWorkflowDefinitionInput(r *http.Request) (*models.UpdateWorkflowDe
 	data, err := ioutil.ReadAll(r.Body)
 
 	if len(data) > 0 {
+
 		input.NewWorkflowDefinitionRequest = &models.NewWorkflowDefinitionRequest{}
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.NewWorkflowDefinitionRequest); err != nil {
 			return nil, err
 		}
+
 	}
 
 	nameStr := mux.Vars(r)["name"]
@@ -1354,7 +1366,9 @@ func (h handler) StartWorkflowHandler(ctx context.Context, w http.ResponseWriter
 		return
 	}
 
-	err = input.Validate(nil)
+	if input != nil {
+		err = input.Validate(nil)
+	}
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
@@ -1393,20 +1407,22 @@ func (h handler) StartWorkflowHandler(ctx context.Context, w http.ResponseWriter
 
 // newStartWorkflowInput takes in an http.Request an returns the input struct.
 func newStartWorkflowInput(r *http.Request) (*models.StartWorkflowRequest, error) {
-	var input models.StartWorkflowRequest
-
 	var err error
 	_ = err
 
 	data, err := ioutil.ReadAll(r.Body)
 
 	if len(data) > 0 {
+
+		var input models.StartWorkflowRequest
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&input); err != nil {
 			return nil, err
 		}
+		return &input, nil
+
 	}
 
-	return &input, nil
+	return nil, nil
 }
 
 // statusCodeForCancelWorkflow returns the status code corresponding to the returned
@@ -1505,10 +1521,12 @@ func newCancelWorkflowInput(r *http.Request) (*models.CancelWorkflowInput, error
 	}
 
 	if len(data) > 0 {
+
 		input.Reason = &models.CancelReason{}
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.Reason); err != nil {
 			return nil, err
 		}
+
 	}
 
 	return &input, nil
@@ -1715,10 +1733,12 @@ func newResumeWorkflowByIDInput(r *http.Request) (*models.ResumeWorkflowByIDInpu
 	}
 
 	if len(data) > 0 {
+
 		input.Overrides = &models.WorkflowDefinitionOverrides{}
 		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.Overrides); err != nil {
 			return nil, err
 		}
+
 	}
 
 	return &input, nil

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -73,6 +73,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_workflow-manager--WorkflowManager.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;workflow-manager-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -128,6 +128,8 @@ class WorkflowManager {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:workflow-manager.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("workflow-manager-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class WorkflowManager {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize workflow-manager without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive;
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -277,7 +284,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/_health",
         json: true,
@@ -286,6 +293,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -393,7 +403,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/state-resources",
         json: true,
@@ -402,6 +412,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.NewStateResource;
   
@@ -519,7 +532,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "DELETE",
         uri: this.address + "/state-resources/" + params.namespace + "/" + params.name + "",
         json: true,
@@ -528,6 +541,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -649,7 +665,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/state-resources/" + params.namespace + "/" + params.name + "",
         json: true,
@@ -658,6 +674,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -779,7 +798,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "PUT",
         uri: this.address + "/state-resources/" + params.namespace + "/" + params.name + "",
         json: true,
@@ -788,6 +807,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.NewStateResource;
   
@@ -896,7 +918,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflow-definitions",
         json: true,
@@ -905,6 +927,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1012,7 +1037,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/workflow-definitions",
         json: true,
@@ -1021,6 +1046,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.NewWorkflowDefinitionRequest;
   
@@ -1138,7 +1166,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflow-definitions/" + params.name + "",
         json: true,
@@ -1147,6 +1175,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1264,7 +1295,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "PUT",
         uri: this.address + "/workflow-definitions/" + params.name + "",
         json: true,
@@ -1273,6 +1304,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.NewWorkflowDefinitionRequest;
   
@@ -1396,7 +1430,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflow-definitions/" + params.name + "/" + params.version + "",
         json: true,
@@ -1405,6 +1439,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1549,7 +1586,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflows",
         json: true,
@@ -1558,6 +1595,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1691,7 +1731,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflows",
         json: true,
@@ -1700,6 +1740,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1853,7 +1896,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/workflows",
         json: true,
@@ -1862,6 +1905,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.StartWorkflowRequest;
   
@@ -1981,7 +2027,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "DELETE",
         uri: this.address + "/workflows/" + params.workflowID + "",
         json: true,
@@ -1990,6 +2036,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.reason;
   
@@ -2110,7 +2159,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/workflows/" + params.workflowID + "",
         json: true,
@@ -2119,6 +2168,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -2236,7 +2288,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/workflows/" + params.workflowID + "",
         json: true,
@@ -2245,6 +2297,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
       requestOptions.body = params.overrides;
   
@@ -2366,7 +2421,7 @@ class WorkflowManager {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/workflows/" + params.workflowID + "/resolved",
         json: true,
@@ -2375,6 +2430,9 @@ class WorkflowManager {
         qs: query,
         useQuerystring: true,
       };
+      if (this.keepalive) {
+        requestOptions.forever = true;
+      }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/satori/go.uuid"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
-	"github.com/Clever/workflow-manager/gen-go/server/db"
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
 )
@@ -89,11 +88,11 @@ func (s MemoryStore) GetWorkflowDefinitionVersions(ctx context.Context, name str
 
 func (s MemoryStore) GetWorkflowDefinition(ctx context.Context, name string, version int) (models.WorkflowDefinition, error) {
 	if _, ok := s.workflowDefinitions[name]; !ok {
-		return models.WorkflowDefinition{}, db.ErrWorkflowDefinitionNotFound{Name: name, Version: int64(version)}
+		return models.WorkflowDefinition{}, store.NewNotFound(fmt.Sprintf("%s@%d", name, version))
 	}
 
 	if len(s.workflowDefinitions[name]) < version {
-		return models.WorkflowDefinition{}, db.ErrWorkflowDefinitionNotFound{Name: name, Version: int64(version)}
+		return models.WorkflowDefinition{}, store.NewNotFound(fmt.Sprintf("%s@%d", name, version))
 	}
 
 	return s.workflowDefinitions[name][version], nil

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Clever/workflow-manager/gen-go/models"
-	"github.com/Clever/workflow-manager/gen-go/server/db"
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
 	"github.com/stretchr/testify/require"
@@ -53,7 +52,7 @@ func UpdateWorkflowDefinition(s store.Store, t *testing.T) func(t *testing.T) {
 		// update kitchensink workflow
 		wflatest.StateMachine.Comment = "update the description"
 		wfupdated, err := s.UpdateWorkflowDefinition(ctx, wflatest)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, wfupdated.StateMachine.Comment, "update the description")
 		require.Equal(t, wfupdated.Version, wflatest.Version+1)
 		require.WithinDuration(t, time.Time(wfupdated.CreatedAt), time.Now(), 1*time.Second)
@@ -99,7 +98,7 @@ func GetWorkflowDefinition(s store.Store, t *testing.T) func(t *testing.T) {
 
 		_, err = s.GetWorkflowDefinition(ctx, "doesntexist", 1)
 		require.NotNil(t, err)
-		require.IsType(t, err, db.ErrWorkflowDefinitionNotFound{})
+		require.IsType(t, err, models.NotFound{})
 	}
 }
 


### PR DESCRIPTION
Currently, going to this URL will crash workflow-manager: https://production--workflow-manager.int.clever.com/workflow-definitions/alskdjf/0

This PR is trying to fix that bug

- Upgraded to the latest WAG
- Removed references to WAG DB code.  The latest WAG had backwards incompatible changes to the DB package.  The only function that used this code was `GetWorkflowDefinition`.  It now uses the dynamo library directly.
- Changed some log levels to Trace

cc @mohit 
