### PR TITLE
The /workflows endpoint can now filter by both status and resolvedByUser

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,6 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"
-  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"

--- a/handler.go
+++ b/handler.go
@@ -197,11 +197,6 @@ func (h Handler) GetWorkflows(
 
 func paramsToWorkflowsQuery(input *models.GetWorkflowsInput) (*models.WorkflowQuery, error) {
 	// due to limitations of DynamoDB indices, only search by status or resolvedByUser, not both at once
-	if input.Status != nil && input.ResolvedByUser != nil {
-		return &models.WorkflowQuery{}, models.BadRequest{
-			Message: "Request cannot contain both status and resolvedByUser.",
-		}
-	}
 	resolvedByUserInformation := &models.ResolvedByUserWrapper{}
 	if input.ResolvedByUser != nil {
 		resolvedByUserInformation = &models.ResolvedByUserWrapper{

--- a/handler_test.go
+++ b/handler_test.go
@@ -65,8 +65,10 @@ func TestParamsToWorkflowsQuery(t *testing.T) {
 	}
 
 	workflowQuery, err := paramsToWorkflowsQuery(inputWithStatusAndResolvedTrue)
-	assert.Error(t, err)
-	assert.IsType(t, models.BadRequest{}, err)
+	assert.NoError(t, err)
+	assert.Equal(t, true, workflowQuery.ResolvedByUserWrapper.IsSet)
+	assert.Equal(t, true, workflowQuery.ResolvedByUserWrapper.Value)
+	assert.Equal(t, models.WorkflowStatusFailed, workflowQuery.Status)
 
 	// if status and resolvedByUser are sent, verify error
 	inputWithStatusAndResolvedFalse := &models.GetWorkflowsInput{
@@ -75,7 +77,10 @@ func TestParamsToWorkflowsQuery(t *testing.T) {
 		WorkflowDefinitionName: definitionName,
 	}
 	workflowQuery, err = paramsToWorkflowsQuery(inputWithStatusAndResolvedFalse)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.Equal(t, true, workflowQuery.ResolvedByUserWrapper.IsSet)
+	assert.Equal(t, false, workflowQuery.ResolvedByUserWrapper.Value)
+	assert.Equal(t, models.WorkflowStatusFailed, workflowQuery.Status)
 
 	// if resolvedByUser is sent, verify that the wrapper is created correctly
 	inputWithResolvedTrue := &models.GetWorkflowsInput{

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -585,7 +585,6 @@ func (d DynamoDB) GetWorkflows(ctx context.Context, query *models.WorkflowQuery)
 	// Use resolvedByUser index if querying by both Status and isReolvedByUser.  The resolvedByUser
 	// index is smaller and typically shrinks over time, so it should be faster to query
 	if resolvedByUserIsSet {
-		// otherwise, if query includes a ResolvedByUser value that is set, query with the ResolvedByUser value
 		dbQuery, err = ddbWorkflowSecondaryKeyDefinitionResolvedByUserCreatedAt{}.ConstructQuery(query)
 
 		if statusIsSet { // Enables filter by isResolvedByUser and Status

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -581,17 +581,26 @@ func (d DynamoDB) GetWorkflows(ctx context.Context, query *models.WorkflowQuery)
 	var err error
 	statusIsSet := query.Status != ""
 	resolvedByUserIsSet := query.ResolvedByUserWrapper != nil && query.ResolvedByUserWrapper.IsSet
-	// status should never be nonempty when ResolvedByUser.IsSet is true, based on handler.
-	if statusIsSet && resolvedByUserIsSet {
-		return workflows, nextPageToken, store.NewInvalidQueryStructureError("query cannot contain Status when ResolvedByUser value is set.")
-	}
 
-	if statusIsSet {
-		// if query includes status, query by status
-		dbQuery, err = ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}.ConstructQuery(query)
-	} else if resolvedByUserIsSet {
+	// Use resolvedByUser index if querying by both Status and isReolvedByUser.  The resolvedByUser
+	// index is smaller and typically shrinks over time, so it should be faster to query
+	if resolvedByUserIsSet {
 		// otherwise, if query includes a ResolvedByUser value that is set, query with the ResolvedByUser value
 		dbQuery, err = ddbWorkflowSecondaryKeyDefinitionResolvedByUserCreatedAt{}.ConstructQuery(query)
+
+		if statusIsSet { // Enables filter by isResolvedByUser and Status
+			statusIdx := ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}
+			pair := statusIdx.getDefinitionStatusPair(*query.WorkflowDefinitionName, string(query.Status))
+
+			dbQuery.SetFilterExpression("#ST = :status")
+			dbQuery.ExpressionAttributeNames["#ST"] = statusIdx.AttributeDefinitions()[0].AttributeName
+			dbQuery.ExpressionAttributeValues[":status"] = &dynamodb.AttributeValue{
+				S: aws.String(pair),
+			}
+		}
+	} else if statusIsSet {
+		// if query includes status, query by status
+		dbQuery, err = ddbWorkflowSecondaryKeyDefinitionStatusCreatedAt{}.ConstructQuery(query)
 	} else {
 		// otherwise, query on just the workflow definition name
 		dbQuery, err = ddbWorkflowSecondaryKeyWorkflowDefinitionCreatedAt{

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -175,13 +175,6 @@ func (s MemoryStore) GetWorkflows(ctx context.Context,
 ) ([]models.Workflow, string, error) {
 	workflows := []models.Workflow{}
 
-	statusIsSet := query.Status != ""
-	resolvedByUserIsSet := query.ResolvedByUserWrapper != nil && query.ResolvedByUserWrapper.IsSet
-	// status should never be nonempty when ResolvedByUser.IsSet is true, based on handler.
-	if statusIsSet && resolvedByUserIsSet {
-		return workflows, "", store.NewInvalidQueryStructureError("query cannot contain Status when ResolvedByUser value is set.")
-	}
-
 	for _, workflow := range s.workflows {
 		if s.matchesQuery(workflow, query) {
 			if aws.BoolValue(query.SummaryOnly) {

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -432,7 +432,11 @@ func GetWorkflows(s store.Store, t *testing.T) func(t *testing.T) {
 			},
 			Limit: 10,
 		})
-		require.Error(t, err)
+		require.NoError(t, err)
+		require.Len(t, workflows, 1)
+		require.Equal(t, runningResolvedWorkflow.ID, workflows[0].ID)
+		require.True(t, workflows[0].ResolvedByUser)
+		require.Equal(t, models.WorkflowStatusRunning, workflows[0].Status)
 	}
 }
 


### PR DESCRIPTION
Workflow-manager now allows people filter to filter by `status` is `resolvedByUser`.  It uses a [Filter Query](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.FilterExpression) to ensure the query remain performant.  Filter Queries filter after they query is completed.  In other words:
> a Query will consume the same amount of read capacity, regardless of whether a filter expression is present.

cc @mohit 