### PR TITLE
update kayvee-go version to stop crashes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -309,10 +309,10 @@
   revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
 
 [[projects]]
+  branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "da425ebb7609ba06a0f395fc8a254d1c303364a0"
-  version = "v1.0"
+  revision = "f3a9dae5b19473510a3062802a98815f609ed747"
 
 [[projects]]
   branch = "master"
@@ -407,8 +407,8 @@
     "middleware",
     "router"
   ]
-  revision = "e03ef3cfc5769be7e502dde84ef35d9d726aef6e"
-  version = "v6.13.0"
+  revision = "c8c3a96b8862f1b962ba9febf5afd2a1c3789fe0"
+  version = "v6.15.0"
 
 [[projects]]
   branch = "v2"
@@ -434,6 +434,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c35ad254cca1e7082af83c4c625683a1fb6f1fdbaa34932ec254cb6b59c722e4"
+  inputs-digest = "e8bb16ab10d63a57149e640def26b061b903492c30d1d32c132906b178189498"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,7 +67,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  version = "^6.10.0"
+  version = "^6.15.0"
 
 [[constraint]]
   name = "gopkg.in/tylerb/graceful.v1"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.2
+*Version* : 0.9.3
 
 
 ### URI scheme

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.2
+  version: 0.9.3
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
Uses new version of `kayvee-go` to avoid container crashes from a race condition in that library. The `kayvee-go` code change (https://github.com/Clever/kayvee-go/pull/71) to avoid the race condition got released as version 6.15.0.
 
- [x] Update swagger.yml version
- [x] Run "make generate"
