### PR TITLE
Increased global timeout to 5 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		store:   db,
 		manager: wfmSFN,
 	}
-	timeout := 5 * time.Second
+	timeout := 10 * time.Second
 	s := server.NewWithMiddleware(h, *addr, []func(http.Handler) http.Handler{
 		func(handler http.Handler) http.Handler {
 			return http.TimeoutHandler(handler, timeout, "Request timed out")


### PR DESCRIPTION
Hubble and ark are seeing timeouts from workflows.  This is hopefully a quick fix