### PR TITLE
Revert "Increased global timeout to 5 seconds"

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 		store:   db,
 		manager: wfmSFN,
 	}
-	timeout := 10 * time.Second
+	timeout := 5 * time.Second
 	s := server.NewWithMiddleware(h, *addr, []func(http.Handler) http.Handler{
 		func(handler http.Handler) http.Handler {
 			return http.TimeoutHandler(handler, timeout, "Request timed out")


### PR DESCRIPTION
Reverts Clever/workflow-manager#154

Root cause of hitting the 5s timeout was the default dynamodb client retry strategy of 10 retries, with (50ms * 2^n) backoff after the nth try: https://github.com/aws/aws-sdk-go/blob/v1.13.0/service/dynamodb/customizations.go This meant we could potentially wait up to (2^9 + 2^8 + ... 2)*50 milliseconds or ~50 seconds for retries to complete. @toddobryan-clever changed the max number of retries to 2 and the p99 immediately dropped back down to reasonable levels.