### PR TITLE
update loop should not look at jobs array when deciding to requeue

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -119,7 +119,7 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	// and re-queue a new message if the worfklow remains pending.
 	defer func() {
 		deleteMsg()
-		if !resources.WorkflowIsDone(&wf) {
+		if !resources.WorkflowStatusIsDone(&wf) {
 			requeueMsg()
 		}
 	}()

--- a/resources/workflows.go
+++ b/resources/workflows.go
@@ -73,6 +73,11 @@ func WorkflowIsDone(wf *models.Workflow) bool {
 			return false
 		}
 	}
+	return WorkflowStatusIsDone(wf)
+}
+
+// WorkflowStatusIsDone return true if a workflow's status is a final state (cancelled, failed, succeeded).
+func WorkflowStatusIsDone(wf *models.Workflow) bool {
 	return (wf.Status == models.WorkflowStatusCancelled ||
 		wf.Status == models.WorkflowStatusFailed ||
 		wf.Status == models.WorkflowStatusSucceeded)


### PR DESCRIPTION
I took a peek at the SQS queue and found some workflows that were
really old, but still in the queue. Turns out these workflows were
finished, but had jobs that were still "in progress". This would
happen if someone loaded it in hubble (triggering an update of the
jobs array), but then never again loaded it.

The workflow.Jobs array is kind of a dumpster fire right now, so I'm
not entirely surprised by this bug... in the long run I think it
should be removed from the workflow object.

Here's an example workflow with the problem:

id: 53332426-43c8-4746-bcdb-47f8f3f545a8

discovered it by polling the SQS queue in the console and noticing that it was showing up more than once

looked it up in dynamo and saw that it was started / finished two weeks ago:
![image](https://user-images.githubusercontent.com/72655/47815770-870f2f00-dd0e-11e8-8c29-f573bc37d1d5.png)
![image](https://user-images.githubusercontent.com/72655/47815820-a4dc9400-dd0e-11e8-98d5-15ae76053eae.png)

Note the final job in the jobs array shows up as "running"
Discovered that the update loop is looking at the jobs array, despite the jobs array no longer getting updated in the update loop. This PR fixes that.
