### PR TITLE
Relax go mock version requirement

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -177,14 +177,14 @@
   version = "0.16.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/mock"
   packages = [
     "gomock",
     "mockgen",
     "mockgen/model"
   ]
-  revision = "600781dde9cca80734169b9e969d9054ccc57937"
+  revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -434,6 +434,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e8bb16ab10d63a57149e640def26b061b903492c30d1d32c132906b178189498"
+  inputs-digest = "8c7a55b4cc1fc3e5497c08d8692e103e7af4ee3ebe67ddaeef201bc044a09744"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,6 +90,12 @@
   version = "v1.15.47"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/codahale/hdrhistogram"
+  packages = ["."]
+  revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
@@ -187,19 +193,6 @@
   version = "v1.2.0"
 
 [[projects]]
-  name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "protoc-gen-go/descriptor",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
-
-[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
@@ -230,18 +223,6 @@
   name = "github.com/kardianos/osext"
   packages = ["."]
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
-
-[[projects]]
-  name = "github.com/lightstep/lightstep-tracer-go"
-  packages = [
-    ".",
-    "collectorpb",
-    "lightstep_thrift",
-    "lightsteppb",
-    "thrift_0_9_2/lib/go/thrift"
-  ]
-  revision = "ee5c8997bd8d23c5086ee174c8bc698c3edff871"
-  version = "v0.15.4"
 
 [[projects]]
   branch = "master"
@@ -276,6 +257,12 @@
   version = "v1.0.2"
 
 [[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -295,6 +282,36 @@
   ]
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
+
+[[projects]]
+  name = "github.com/uber/jaeger-client-go"
+  packages = [
+    ".",
+    "config",
+    "internal/baggage",
+    "internal/baggage/remote",
+    "internal/spanlog",
+    "internal/throttler",
+    "internal/throttler/remote",
+    "log",
+    "rpcmetrics",
+    "thrift",
+    "thrift-gen/agent",
+    "thrift-gen/baggage",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "transport",
+    "utils"
+  ]
+  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
+  version = "v2.15.0"
+
+[[projects]]
+  name = "github.com/uber/jaeger-lib"
+  packages = ["metrics"]
+  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
@@ -320,20 +337,9 @@
   packages = [
     "context",
     "context/ctxhttp",
-    "http/httpguts",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "trace"
+    "idna"
   ]
   revision = "f5e5bdd778241bfefa8627f7124c39cd6ad8d74f"
-
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "af653ce8b74f808d092db8ca9741fbb63d2a469d"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -356,48 +362,6 @@
   ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
-
-[[projects]]
-  branch = "master"
-  name = "google.golang.org/genproto"
-  packages = [
-    "googleapis/api/annotations",
-    "googleapis/rpc/status"
-  ]
-  revision = "c7e5094acea1ca1b899e2259d80a6b0f882f81f8"
-
-[[projects]]
-  name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "codes",
-    "connectivity",
-    "credentials",
-    "encoding",
-    "encoding/proto",
-    "grpclog",
-    "internal",
-    "internal/backoff",
-    "internal/channelz",
-    "internal/envconfig",
-    "internal/grpcrand",
-    "internal/transport",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap"
-  ]
-  revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
-  version = "v1.15.0"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
@@ -434,6 +398,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8c7a55b4cc1fc3e5497c08d8692e103e7af4ee3ebe67ddaeef201bc044a09744"
+  inputs-digest = "f1828ab4ac6313e3fc6ec22bee6497c80f4cafc03752c2f455bac70857e58fef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "github.com/golang/mock"
-  branch = "master"
+  version = "^1.2.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,3 +71,7 @@ required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "gopkg.in/tylerb/graceful.v1"
+
+[[constraint]]
+  name = "github.com/uber/jaeger-client-go"
+  version = "2.15.0"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.3
+*Version* : 0.9.4
 
 
 ### URI scheme

--- a/gen-go/client/doer.go
+++ b/gen-go/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/gen-go/client/mock_client.go
+++ b/gen-go/client/mock_client.go
@@ -36,6 +36,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // HealthCheck mocks base method
 func (m *MockClient) HealthCheck(ctx context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HealthCheck", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +44,13 @@ func (m *MockClient) HealthCheck(ctx context.Context) error {
 
 // HealthCheck indicates an expected call of HealthCheck
 func (mr *MockClientMockRecorder) HealthCheck(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheck", reflect.TypeOf((*MockClient)(nil).HealthCheck), ctx)
 }
 
 // PostStateResource mocks base method
 func (m *MockClient) PostStateResource(ctx context.Context, i *models.NewStateResource) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -56,11 +59,13 @@ func (m *MockClient) PostStateResource(ctx context.Context, i *models.NewStateRe
 
 // PostStateResource indicates an expected call of PostStateResource
 func (mr *MockClientMockRecorder) PostStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostStateResource", reflect.TypeOf((*MockClient)(nil).PostStateResource), ctx, i)
 }
 
 // DeleteStateResource mocks base method
 func (m *MockClient) DeleteStateResource(ctx context.Context, i *models.DeleteStateResourceInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStateResource", ctx, i)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -68,11 +73,13 @@ func (m *MockClient) DeleteStateResource(ctx context.Context, i *models.DeleteSt
 
 // DeleteStateResource indicates an expected call of DeleteStateResource
 func (mr *MockClientMockRecorder) DeleteStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStateResource", reflect.TypeOf((*MockClient)(nil).DeleteStateResource), ctx, i)
 }
 
 // GetStateResource mocks base method
 func (m *MockClient) GetStateResource(ctx context.Context, i *models.GetStateResourceInput) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -81,11 +88,13 @@ func (m *MockClient) GetStateResource(ctx context.Context, i *models.GetStateRes
 
 // GetStateResource indicates an expected call of GetStateResource
 func (mr *MockClientMockRecorder) GetStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateResource", reflect.TypeOf((*MockClient)(nil).GetStateResource), ctx, i)
 }
 
 // PutStateResource mocks base method
 func (m *MockClient) PutStateResource(ctx context.Context, i *models.PutStateResourceInput) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -94,11 +103,13 @@ func (m *MockClient) PutStateResource(ctx context.Context, i *models.PutStateRes
 
 // PutStateResource indicates an expected call of PutStateResource
 func (mr *MockClientMockRecorder) PutStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutStateResource", reflect.TypeOf((*MockClient)(nil).PutStateResource), ctx, i)
 }
 
 // GetWorkflowDefinitions mocks base method
 func (m *MockClient) GetWorkflowDefinitions(ctx context.Context) ([]models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitions", ctx)
 	ret0, _ := ret[0].([]models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -107,11 +118,13 @@ func (m *MockClient) GetWorkflowDefinitions(ctx context.Context) ([]models.Workf
 
 // GetWorkflowDefinitions indicates an expected call of GetWorkflowDefinitions
 func (mr *MockClientMockRecorder) GetWorkflowDefinitions(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitions", reflect.TypeOf((*MockClient)(nil).GetWorkflowDefinitions), ctx)
 }
 
 // NewWorkflowDefinition mocks base method
 func (m *MockClient) NewWorkflowDefinition(ctx context.Context, i *models.NewWorkflowDefinitionRequest) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWorkflowDefinition", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -120,11 +133,13 @@ func (m *MockClient) NewWorkflowDefinition(ctx context.Context, i *models.NewWor
 
 // NewWorkflowDefinition indicates an expected call of NewWorkflowDefinition
 func (mr *MockClientMockRecorder) NewWorkflowDefinition(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWorkflowDefinition", reflect.TypeOf((*MockClient)(nil).NewWorkflowDefinition), ctx, i)
 }
 
 // GetWorkflowDefinitionVersionsByName mocks base method
 func (m *MockClient) GetWorkflowDefinitionVersionsByName(ctx context.Context, i *models.GetWorkflowDefinitionVersionsByNameInput) ([]models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitionVersionsByName", ctx, i)
 	ret0, _ := ret[0].([]models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -133,11 +148,13 @@ func (m *MockClient) GetWorkflowDefinitionVersionsByName(ctx context.Context, i 
 
 // GetWorkflowDefinitionVersionsByName indicates an expected call of GetWorkflowDefinitionVersionsByName
 func (mr *MockClientMockRecorder) GetWorkflowDefinitionVersionsByName(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitionVersionsByName", reflect.TypeOf((*MockClient)(nil).GetWorkflowDefinitionVersionsByName), ctx, i)
 }
 
 // UpdateWorkflowDefinition mocks base method
 func (m *MockClient) UpdateWorkflowDefinition(ctx context.Context, i *models.UpdateWorkflowDefinitionInput) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowDefinition", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -146,11 +163,13 @@ func (m *MockClient) UpdateWorkflowDefinition(ctx context.Context, i *models.Upd
 
 // UpdateWorkflowDefinition indicates an expected call of UpdateWorkflowDefinition
 func (mr *MockClientMockRecorder) UpdateWorkflowDefinition(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowDefinition", reflect.TypeOf((*MockClient)(nil).UpdateWorkflowDefinition), ctx, i)
 }
 
 // GetWorkflowDefinitionByNameAndVersion mocks base method
 func (m *MockClient) GetWorkflowDefinitionByNameAndVersion(ctx context.Context, i *models.GetWorkflowDefinitionByNameAndVersionInput) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitionByNameAndVersion", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -159,11 +178,13 @@ func (m *MockClient) GetWorkflowDefinitionByNameAndVersion(ctx context.Context, 
 
 // GetWorkflowDefinitionByNameAndVersion indicates an expected call of GetWorkflowDefinitionByNameAndVersion
 func (mr *MockClientMockRecorder) GetWorkflowDefinitionByNameAndVersion(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitionByNameAndVersion", reflect.TypeOf((*MockClient)(nil).GetWorkflowDefinitionByNameAndVersion), ctx, i)
 }
 
 // GetWorkflows mocks base method
 func (m *MockClient) GetWorkflows(ctx context.Context, i *models.GetWorkflowsInput) ([]models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflows", ctx, i)
 	ret0, _ := ret[0].([]models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -172,11 +193,13 @@ func (m *MockClient) GetWorkflows(ctx context.Context, i *models.GetWorkflowsInp
 
 // GetWorkflows indicates an expected call of GetWorkflows
 func (mr *MockClientMockRecorder) GetWorkflows(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflows", reflect.TypeOf((*MockClient)(nil).GetWorkflows), ctx, i)
 }
 
 // NewGetWorkflowsIter mocks base method
 func (m *MockClient) NewGetWorkflowsIter(ctx context.Context, i *models.GetWorkflowsInput) (GetWorkflowsIter, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewGetWorkflowsIter", ctx, i)
 	ret0, _ := ret[0].(GetWorkflowsIter)
 	ret1, _ := ret[1].(error)
@@ -185,11 +208,13 @@ func (m *MockClient) NewGetWorkflowsIter(ctx context.Context, i *models.GetWorkf
 
 // NewGetWorkflowsIter indicates an expected call of NewGetWorkflowsIter
 func (mr *MockClientMockRecorder) NewGetWorkflowsIter(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetWorkflowsIter", reflect.TypeOf((*MockClient)(nil).NewGetWorkflowsIter), ctx, i)
 }
 
 // StartWorkflow mocks base method
 func (m *MockClient) StartWorkflow(ctx context.Context, i *models.StartWorkflowRequest) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartWorkflow", ctx, i)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -198,11 +223,13 @@ func (m *MockClient) StartWorkflow(ctx context.Context, i *models.StartWorkflowR
 
 // StartWorkflow indicates an expected call of StartWorkflow
 func (mr *MockClientMockRecorder) StartWorkflow(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorkflow", reflect.TypeOf((*MockClient)(nil).StartWorkflow), ctx, i)
 }
 
 // CancelWorkflow mocks base method
 func (m *MockClient) CancelWorkflow(ctx context.Context, i *models.CancelWorkflowInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelWorkflow", ctx, i)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -210,11 +237,13 @@ func (m *MockClient) CancelWorkflow(ctx context.Context, i *models.CancelWorkflo
 
 // CancelWorkflow indicates an expected call of CancelWorkflow
 func (mr *MockClientMockRecorder) CancelWorkflow(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelWorkflow", reflect.TypeOf((*MockClient)(nil).CancelWorkflow), ctx, i)
 }
 
 // GetWorkflowByID mocks base method
 func (m *MockClient) GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowByID", ctx, workflowID)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -223,11 +252,13 @@ func (m *MockClient) GetWorkflowByID(ctx context.Context, workflowID string) (*m
 
 // GetWorkflowByID indicates an expected call of GetWorkflowByID
 func (mr *MockClientMockRecorder) GetWorkflowByID(ctx, workflowID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowByID", reflect.TypeOf((*MockClient)(nil).GetWorkflowByID), ctx, workflowID)
 }
 
 // ResumeWorkflowByID mocks base method
 func (m *MockClient) ResumeWorkflowByID(ctx context.Context, i *models.ResumeWorkflowByIDInput) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeWorkflowByID", ctx, i)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -236,11 +267,13 @@ func (m *MockClient) ResumeWorkflowByID(ctx context.Context, i *models.ResumeWor
 
 // ResumeWorkflowByID indicates an expected call of ResumeWorkflowByID
 func (mr *MockClientMockRecorder) ResumeWorkflowByID(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeWorkflowByID", reflect.TypeOf((*MockClient)(nil).ResumeWorkflowByID), ctx, i)
 }
 
 // ResolveWorkflowByID mocks base method
 func (m *MockClient) ResolveWorkflowByID(ctx context.Context, workflowID string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWorkflowByID", ctx, workflowID)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -248,6 +281,7 @@ func (m *MockClient) ResolveWorkflowByID(ctx context.Context, workflowID string)
 
 // ResolveWorkflowByID indicates an expected call of ResolveWorkflowByID
 func (mr *MockClientMockRecorder) ResolveWorkflowByID(ctx, workflowID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWorkflowByID", reflect.TypeOf((*MockClient)(nil).ResolveWorkflowByID), ctx, workflowID)
 }
 
@@ -276,6 +310,7 @@ func (m *MockGetWorkflowsIter) EXPECT() *MockGetWorkflowsIterMockRecorder {
 
 // Next mocks base method
 func (m *MockGetWorkflowsIter) Next(arg0 *models.Workflow) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -283,11 +318,13 @@ func (m *MockGetWorkflowsIter) Next(arg0 *models.Workflow) bool {
 
 // Next indicates an expected call of Next
 func (mr *MockGetWorkflowsIterMockRecorder) Next(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockGetWorkflowsIter)(nil).Next), arg0)
 }
 
 // Err mocks base method
 func (m *MockGetWorkflowsIter) Err() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -295,5 +332,6 @@ func (m *MockGetWorkflowsIter) Err() error {
 
 // Err indicates an expected call of Err
 func (mr *MockGetWorkflowsIterMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockGetWorkflowsIter)(nil).Err))
 }

--- a/gen-go/server/db/dynamodb/workflowdefinition.go
+++ b/gen-go/server/db/dynamodb/workflowdefinition.go
@@ -45,11 +45,11 @@ func (t WorkflowDefinitionTable) create(ctx context.Context) error {
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
 			{
 				AttributeName: aws.String("name"),
-				AttributeType: aws.String(dynamodb.ScalarAttributeTypeS),
+				AttributeType: aws.String("S"),
 			},
 			{
 				AttributeName: aws.String("version"),
-				AttributeType: aws.String(dynamodb.ScalarAttributeTypeN),
+				AttributeType: aws.String("N"),
 			},
 		},
 		KeySchema: []*dynamodb.KeySchemaElement{

--- a/gen-go/server/db/tests/tests.go
+++ b/gen-go/server/db/tests/tests.go
@@ -166,10 +166,7 @@ func SaveWorkflowDefinition(s db.Interface, t *testing.T) func(t *testing.T) {
 			Version: 1,
 		}
 		require.Nil(t, s.SaveWorkflowDefinition(ctx, m))
-		require.Equal(t, db.ErrWorkflowDefinitionAlreadyExists{
-			Name:    "string1",
-			Version: 1,
-		}, s.SaveWorkflowDefinition(ctx, m))
+		require.IsType(t, db.ErrWorkflowDefinitionAlreadyExists{}, s.SaveWorkflowDefinition(ctx, m))
 	}
 }
 

--- a/gen-go/server/mock_controller.go
+++ b/gen-go/server/mock_controller.go
@@ -36,6 +36,7 @@ func (m *MockController) EXPECT() *MockControllerMockRecorder {
 
 // HealthCheck mocks base method
 func (m *MockController) HealthCheck(ctx context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HealthCheck", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +44,13 @@ func (m *MockController) HealthCheck(ctx context.Context) error {
 
 // HealthCheck indicates an expected call of HealthCheck
 func (mr *MockControllerMockRecorder) HealthCheck(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheck", reflect.TypeOf((*MockController)(nil).HealthCheck), ctx)
 }
 
 // PostStateResource mocks base method
 func (m *MockController) PostStateResource(ctx context.Context, i *models.NewStateResource) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -56,11 +59,13 @@ func (m *MockController) PostStateResource(ctx context.Context, i *models.NewSta
 
 // PostStateResource indicates an expected call of PostStateResource
 func (mr *MockControllerMockRecorder) PostStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostStateResource", reflect.TypeOf((*MockController)(nil).PostStateResource), ctx, i)
 }
 
 // DeleteStateResource mocks base method
 func (m *MockController) DeleteStateResource(ctx context.Context, i *models.DeleteStateResourceInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStateResource", ctx, i)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -68,11 +73,13 @@ func (m *MockController) DeleteStateResource(ctx context.Context, i *models.Dele
 
 // DeleteStateResource indicates an expected call of DeleteStateResource
 func (mr *MockControllerMockRecorder) DeleteStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStateResource", reflect.TypeOf((*MockController)(nil).DeleteStateResource), ctx, i)
 }
 
 // GetStateResource mocks base method
 func (m *MockController) GetStateResource(ctx context.Context, i *models.GetStateResourceInput) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -81,11 +88,13 @@ func (m *MockController) GetStateResource(ctx context.Context, i *models.GetStat
 
 // GetStateResource indicates an expected call of GetStateResource
 func (mr *MockControllerMockRecorder) GetStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateResource", reflect.TypeOf((*MockController)(nil).GetStateResource), ctx, i)
 }
 
 // PutStateResource mocks base method
 func (m *MockController) PutStateResource(ctx context.Context, i *models.PutStateResourceInput) (*models.StateResource, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutStateResource", ctx, i)
 	ret0, _ := ret[0].(*models.StateResource)
 	ret1, _ := ret[1].(error)
@@ -94,11 +103,13 @@ func (m *MockController) PutStateResource(ctx context.Context, i *models.PutStat
 
 // PutStateResource indicates an expected call of PutStateResource
 func (mr *MockControllerMockRecorder) PutStateResource(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutStateResource", reflect.TypeOf((*MockController)(nil).PutStateResource), ctx, i)
 }
 
 // GetWorkflowDefinitions mocks base method
 func (m *MockController) GetWorkflowDefinitions(ctx context.Context) ([]models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitions", ctx)
 	ret0, _ := ret[0].([]models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -107,11 +118,13 @@ func (m *MockController) GetWorkflowDefinitions(ctx context.Context) ([]models.W
 
 // GetWorkflowDefinitions indicates an expected call of GetWorkflowDefinitions
 func (mr *MockControllerMockRecorder) GetWorkflowDefinitions(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitions", reflect.TypeOf((*MockController)(nil).GetWorkflowDefinitions), ctx)
 }
 
 // NewWorkflowDefinition mocks base method
 func (m *MockController) NewWorkflowDefinition(ctx context.Context, i *models.NewWorkflowDefinitionRequest) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWorkflowDefinition", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -120,11 +133,13 @@ func (m *MockController) NewWorkflowDefinition(ctx context.Context, i *models.Ne
 
 // NewWorkflowDefinition indicates an expected call of NewWorkflowDefinition
 func (mr *MockControllerMockRecorder) NewWorkflowDefinition(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWorkflowDefinition", reflect.TypeOf((*MockController)(nil).NewWorkflowDefinition), ctx, i)
 }
 
 // GetWorkflowDefinitionVersionsByName mocks base method
 func (m *MockController) GetWorkflowDefinitionVersionsByName(ctx context.Context, i *models.GetWorkflowDefinitionVersionsByNameInput) ([]models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitionVersionsByName", ctx, i)
 	ret0, _ := ret[0].([]models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -133,11 +148,13 @@ func (m *MockController) GetWorkflowDefinitionVersionsByName(ctx context.Context
 
 // GetWorkflowDefinitionVersionsByName indicates an expected call of GetWorkflowDefinitionVersionsByName
 func (mr *MockControllerMockRecorder) GetWorkflowDefinitionVersionsByName(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitionVersionsByName", reflect.TypeOf((*MockController)(nil).GetWorkflowDefinitionVersionsByName), ctx, i)
 }
 
 // UpdateWorkflowDefinition mocks base method
 func (m *MockController) UpdateWorkflowDefinition(ctx context.Context, i *models.UpdateWorkflowDefinitionInput) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowDefinition", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -146,11 +163,13 @@ func (m *MockController) UpdateWorkflowDefinition(ctx context.Context, i *models
 
 // UpdateWorkflowDefinition indicates an expected call of UpdateWorkflowDefinition
 func (mr *MockControllerMockRecorder) UpdateWorkflowDefinition(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowDefinition", reflect.TypeOf((*MockController)(nil).UpdateWorkflowDefinition), ctx, i)
 }
 
 // GetWorkflowDefinitionByNameAndVersion mocks base method
 func (m *MockController) GetWorkflowDefinitionByNameAndVersion(ctx context.Context, i *models.GetWorkflowDefinitionByNameAndVersionInput) (*models.WorkflowDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowDefinitionByNameAndVersion", ctx, i)
 	ret0, _ := ret[0].(*models.WorkflowDefinition)
 	ret1, _ := ret[1].(error)
@@ -159,11 +178,13 @@ func (m *MockController) GetWorkflowDefinitionByNameAndVersion(ctx context.Conte
 
 // GetWorkflowDefinitionByNameAndVersion indicates an expected call of GetWorkflowDefinitionByNameAndVersion
 func (mr *MockControllerMockRecorder) GetWorkflowDefinitionByNameAndVersion(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowDefinitionByNameAndVersion", reflect.TypeOf((*MockController)(nil).GetWorkflowDefinitionByNameAndVersion), ctx, i)
 }
 
 // GetWorkflows mocks base method
 func (m *MockController) GetWorkflows(ctx context.Context, i *models.GetWorkflowsInput) ([]models.Workflow, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflows", ctx, i)
 	ret0, _ := ret[0].([]models.Workflow)
 	ret1, _ := ret[1].(string)
@@ -173,11 +194,13 @@ func (m *MockController) GetWorkflows(ctx context.Context, i *models.GetWorkflow
 
 // GetWorkflows indicates an expected call of GetWorkflows
 func (mr *MockControllerMockRecorder) GetWorkflows(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflows", reflect.TypeOf((*MockController)(nil).GetWorkflows), ctx, i)
 }
 
 // StartWorkflow mocks base method
 func (m *MockController) StartWorkflow(ctx context.Context, i *models.StartWorkflowRequest) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartWorkflow", ctx, i)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -186,11 +209,13 @@ func (m *MockController) StartWorkflow(ctx context.Context, i *models.StartWorkf
 
 // StartWorkflow indicates an expected call of StartWorkflow
 func (mr *MockControllerMockRecorder) StartWorkflow(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorkflow", reflect.TypeOf((*MockController)(nil).StartWorkflow), ctx, i)
 }
 
 // CancelWorkflow mocks base method
 func (m *MockController) CancelWorkflow(ctx context.Context, i *models.CancelWorkflowInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelWorkflow", ctx, i)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -198,11 +223,13 @@ func (m *MockController) CancelWorkflow(ctx context.Context, i *models.CancelWor
 
 // CancelWorkflow indicates an expected call of CancelWorkflow
 func (mr *MockControllerMockRecorder) CancelWorkflow(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelWorkflow", reflect.TypeOf((*MockController)(nil).CancelWorkflow), ctx, i)
 }
 
 // GetWorkflowByID mocks base method
 func (m *MockController) GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowByID", ctx, workflowID)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -211,11 +238,13 @@ func (m *MockController) GetWorkflowByID(ctx context.Context, workflowID string)
 
 // GetWorkflowByID indicates an expected call of GetWorkflowByID
 func (mr *MockControllerMockRecorder) GetWorkflowByID(ctx, workflowID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowByID", reflect.TypeOf((*MockController)(nil).GetWorkflowByID), ctx, workflowID)
 }
 
 // ResumeWorkflowByID mocks base method
 func (m *MockController) ResumeWorkflowByID(ctx context.Context, i *models.ResumeWorkflowByIDInput) (*models.Workflow, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeWorkflowByID", ctx, i)
 	ret0, _ := ret[0].(*models.Workflow)
 	ret1, _ := ret[1].(error)
@@ -224,11 +253,13 @@ func (m *MockController) ResumeWorkflowByID(ctx context.Context, i *models.Resum
 
 // ResumeWorkflowByID indicates an expected call of ResumeWorkflowByID
 func (mr *MockControllerMockRecorder) ResumeWorkflowByID(ctx, i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeWorkflowByID", reflect.TypeOf((*MockController)(nil).ResumeWorkflowByID), ctx, i)
 }
 
 // ResolveWorkflowByID mocks base method
 func (m *MockController) ResolveWorkflowByID(ctx context.Context, workflowID string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWorkflowByID", ctx, workflowID)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -236,5 +267,6 @@ func (m *MockController) ResolveWorkflowByID(ctx context.Context, workflowID str
 
 // ResolveWorkflowByID indicates an expected call of ResolveWorkflowByID
 func (mr *MockControllerMockRecorder) ResolveWorkflowByID(ctx, workflowID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWorkflowByID", reflect.TypeOf((*MockController)(nil).ResolveWorkflowByID), ctx, workflowID)
 }

--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -13,8 +13,10 @@ import (
 	"github.com/Clever/go-process-metrics/metrics"
 	"github.com/gorilla/mux"
 	"github.com/kardianos/osext"
-	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
 	"gopkg.in/tylerb/graceful.v1"
@@ -50,18 +52,46 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if lightstepToken := os.Getenv("LIGHTSTEP_ACCESS_TOKEN"); lightstepToken != "" {
-		tags := make(map[string]interface{})
-		tags[lightstep.ComponentNameKey] = "workflow-manager"
-		lightstepTracer := lightstep.NewTracer(lightstep.Options{
-			AccessToken: lightstepToken,
-			Tags:        tags,
-			UseGRPC:     true,
-		})
-		defer lightstep.FlushLightStepTracer(lightstepTracer)
-		opentracing.InitGlobalTracer(lightstepTracer)
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
+		if ingestUrl == "" {
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
+		}
+
+		// Create a Jaeger HTTP Thrift transport
+		transport := transport.NewHTTPTransport(ingestUrl,
+			transport.HTTPBasicAuth("auth", tracingToken))
+
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
+		}
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "workflow-manager",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
+		}
+
+		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
+		if err != nil {
+			log.Fatal("Could not initialize jaeger tracer: ", err.Error())
+		}
+		defer closer.Close()
+
+		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set LIGHTSTEP_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -75,7 +75,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_workflow-manager--WorkflowManager.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;workflow-manager-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;workflow-manager-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -132,7 +132,7 @@ class WorkflowManager {
    * forever: true attribute in request. Defaults to false
    * @param {module:workflow-manager.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("workflow-manager-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("workflow-manager-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -177,6 +177,11 @@ class WorkflowManager {
       this.logger = options.logger;
     } else {
       this.logger =  new kayvee.logger("workflow-manager-wagclient");
+    }
+    if (options.tracer) {
+      this.tracer = options.tracer;
+    } else {
+      this.tracer = opentracing.globalTracer();
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -272,6 +277,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -279,7 +285,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /_health");
         span.setTag("span.kind", "client");
       }
@@ -391,6 +398,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -398,7 +406,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /state-resources");
         span.setTag("span.kind", "client");
       }
@@ -512,6 +521,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -527,7 +537,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("DELETE /state-resources/{namespace}/{name}");
         span.setTag("span.kind", "client");
       }
@@ -645,6 +656,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -660,7 +672,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /state-resources/{namespace}/{name}");
         span.setTag("span.kind", "client");
       }
@@ -778,6 +791,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -793,7 +807,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /state-resources/{namespace}/{name}");
         span.setTag("span.kind", "client");
       }
@@ -906,6 +921,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -913,7 +929,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /workflow-definitions");
         span.setTag("span.kind", "client");
       }
@@ -1025,6 +1042,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1032,7 +1050,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /workflow-definitions");
         span.setTag("span.kind", "client");
       }
@@ -1146,6 +1165,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1161,7 +1181,8 @@ class WorkflowManager {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /workflow-definitions/{name}");
         span.setTag("span.kind", "client");
       }
@@ -1279,6 +1300,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1290,7 +1312,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /workflow-definitions/{name}");
         span.setTag("span.kind", "client");
       }
@@ -1410,6 +1433,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1425,7 +1449,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /workflow-definitions/{name}/{version}");
         span.setTag("span.kind", "client");
       }
@@ -1548,6 +1573,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1581,7 +1607,8 @@ class WorkflowManager {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /workflows");
         span.setTag("span.kind", "client");
       }
@@ -1694,6 +1721,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1727,7 +1755,8 @@ class WorkflowManager {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -1884,6 +1913,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1891,7 +1921,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /workflows");
         span.setTag("span.kind", "client");
       }
@@ -2011,6 +2042,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -2022,7 +2054,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("DELETE /workflows/{workflowID}");
         span.setTag("span.kind", "client");
       }
@@ -2143,6 +2176,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -2154,7 +2188,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /workflows/{workflowID}");
         span.setTag("span.kind", "client");
       }
@@ -2272,6 +2307,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -2283,7 +2319,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /workflows/{workflowID}");
         span.setTag("span.kind", "client");
       }
@@ -2405,6 +2442,7 @@ class WorkflowManager {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -2416,7 +2454,8 @@ class WorkflowManager {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /workflows/{workflowID}/resolved");
         span.setTag("span.kind", "client");
       }

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.3
+  version: 0.9.4
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
#### Relax version requirement on `github.com/golang/mock`

This is causing problems in apps that depend on both App Service and
Workflow Manager.

App Service depends on the latest stable release of
`github.com/golang/mock` which is currently `1.2.0`. Workflow Manger
depends on an even newer version, `master`.

The latest stable release (`1.2.0`) will satisfy the requirements of
App Service, Workflow Manager, and all of the apps that depend on both
Workflow Manager and App Service.

    Solving failure: No versions of github.com/Clever/workflow-manager met constraints:
      0.9.3: Could not introduce github.com/Clever/workflow-manager
      (from git@github.com:Clever/workflow-manager.git)@0.9.3,
      as it has a dependency on github.com/golang/mock with constraint
      master, which has no overlap with the following existing constraints:
      ^1.2.0 from github.com/Clever/app-service
      (from git@github.com:Clever/app-service.git)

- [x] Update swagger.yml version
- [x] Run "make generate"
