### PR TITLE
workflow last attempted state info

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -253,6 +253,8 @@
 |**id**  <br>*optional*||string|
 |**input**  <br>*optional*||string|
 |**jobs**  <br>*optional*||< [Job](#job) > array|
+|**lastAttemptedResource**  <br>*optional*||string|
+|**lastAttemptedState**  <br>*optional*||string|
 |**lastUpdated**  <br>*optional*||string (date-time)|
 |**namespace**  <br>*optional*||string|
 |**output**  <br>*optional*||string|

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.5
+*Version* : 0.10.0
 
 
 ### URI scheme

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -128,6 +128,11 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	if err := wm.UpdateWorkflowSummary(ctx, &wf); err != nil {
 		return "", err
 	}
+	if wf.Status == models.WorkflowStatusFailed {
+		if err := wm.UpdateWorkflowHistory(ctx, &wf); err != nil {
+			return "", err
+		}
+	}
 	storeSaveFailed = false
 	return wfID, nil
 }

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -589,6 +589,14 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 	}
 	workflow.Jobs = jobs
 
+	if len(jobs) > 0 {
+		lastJob := jobs[len(jobs)-1]
+		workflow.LastAttemptedState = lastJob.State
+		if lastJob.StateResource != nil {
+			workflow.LastAttemptedResource = lastJob.StateResource.Name
+		}
+	}
+
 	return wm.store.UpdateWorkflow(ctx, *workflow)
 }
 

--- a/gen-go/models/workflow.go
+++ b/gen-go/models/workflow.go
@@ -22,6 +22,12 @@ type Workflow struct {
 	// jobs
 	Jobs []*Job `json:"jobs"`
 
+	// last attempted resource
+	LastAttemptedResource string `json:"lastAttemptedResource,omitempty"`
+
+	// last attempted state
+	LastAttemptedState string `json:"lastAttemptedState,omitempty"`
+
 	// output
 	Output string `json:"output,omitempty"`
 
@@ -41,6 +47,10 @@ func (m *Workflow) UnmarshalJSON(raw []byte) error {
 	var data struct {
 		Jobs []*Job `json:"jobs,omitempty"`
 
+		LastAttemptedResource string `json:"lastAttemptedResource,omitempty"`
+
+		LastAttemptedState string `json:"lastAttemptedState,omitempty"`
+
 		Output string `json:"output,omitempty"`
 
 		StatusReason string `json:"statusReason,omitempty"`
@@ -50,6 +60,10 @@ func (m *Workflow) UnmarshalJSON(raw []byte) error {
 	}
 
 	m.Jobs = data.Jobs
+
+	m.LastAttemptedResource = data.LastAttemptedResource
+
+	m.LastAttemptedState = data.LastAttemptedState
 
 	m.Output = data.Output
 
@@ -71,12 +85,20 @@ func (m Workflow) MarshalJSON() ([]byte, error) {
 	var data struct {
 		Jobs []*Job `json:"jobs,omitempty"`
 
+		LastAttemptedResource string `json:"lastAttemptedResource,omitempty"`
+
+		LastAttemptedState string `json:"lastAttemptedState,omitempty"`
+
 		Output string `json:"output,omitempty"`
 
 		StatusReason string `json:"statusReason,omitempty"`
 	}
 
 	data.Jobs = m.Jobs
+
+	data.LastAttemptedResource = m.LastAttemptedResource
+
+	data.LastAttemptedState = m.LastAttemptedState
 
 	data.Output = m.Output
 

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.5
+  version: 0.10.0
   x-npm-package: workflow-manager
 schemes:
   - http

--- a/swagger.yml
+++ b/swagger.yml
@@ -433,6 +433,10 @@ definitions:
         properties:
           statusReason:
             type: string
+          lastAttemptedState:
+            type: string
+          lastAttemptedResource:
+            type: string
           output:
             # format: json
             type: string


### PR DESCRIPTION
http://clever.atlassian.net/browse/sync-1172

The hubble/repairs page is slow to load when there are a large number of active workflows. The reason for the slowness is that it iterates through every active workflow and loads the full workflow history for each one. We are in the process of modifying Hubble to query Elasticsearch for active and recent workflows instead of using workflow-manager, and we are also exploring the possibility of querying Elasticsearch for failed workflows. The execution history for a workflow is only loaded when the workflow-manager `GetWorkflowByID` endpoint is called, so the workflow histories do not typically exist in Elasticsearch. https://github.com/Clever/workflow-manager/blob/fbf52f9801e218b223681fa7c7b57bf6db408a45/handler.go#L243

This change adds additional workflow fields to store the last attempted state and resource names, and it populates them in the `UpdateWorkflowHistory` method. The workflow update loop will now call `UpdateWorkflowHistory` whenever a workflow has failed. `lastAttemptedState` and `lastAttemptedResource` automatically make their way to Elasticsearch.


I deployed this change to clever-dev and triggered a workflow that failed. The new fields show up in Elasticsearch without having called `GetWorkflowByID`
```
[renatoprime@Renatos-MacBook-Pro workflow-manager (workflow-last-attempted-state-info)]$ curl https://vpc-workflows-dev-2nfzpvqce62oumm6zcnjaipife.us-west-1.es.amazonaws.com/clever-dev-workflow-manager-dev-v3-workflows/default/c3573673-8e28-47bc-8e43-1073c9c78599 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2449  100  2449    0     0  10544      0 --:--:-- --:--:-- --:--:-- 10556
{
  "_index": "clever-dev-workflow-manager-dev-v3-workflows",
  "_type": "default",
  "_id": "c3573673-8e28-47bc-8e43-1073c9c78599",
  "_version": 6,
  "found": true,
  "_source": {
    "Workflow": {
      "createdAt": "2019-04-22T17:23:07.097148937Z",
      "id": "c3573673-8e28-47bc-8e43-1073c9c78599",
      "input": "{}",
      "jobs": [
        {
          "createdAt": "2019-04-22T17:23:07Z",
          "id": "2",
          "input": "{\"_EXECUTION_NAME\":\"c3573673-8e28-47bc-8e43-1073c9c78599\"}",
          "output": "null",
          "startedAt": "2019-04-22T17:23:07Z",
          "state": "clogger",
          "stateResource": {
            "lastUpdated": "2019-04-22T17:23:07Z",
            "name": "clogger",
            "namespace": "clever-dev",
            "type": "LambdaFunctionARN"
          },
          "status": "succeeded",
          "stoppedAt": "2019-04-22T17:23:07Z"
        },
        {
          "createdAt": "2019-04-22T17:23:07Z",
          "id": "7",
          "input": "null",
          "startedAt": "2019-04-22T17:23:07Z",
          "state": "dpt-clogger",
          "stateResource": {
            "lastUpdated": "2019-04-22T17:23:07Z",
            "name": "dpt-clogger",
            "namespace": "clever-dev",
            "type": "LambdaFunctionARN"
          },
          "status": "failed",
          "statusReason": "{\"errorMessage\":\"fork/exec /var/task/dpt-clogger: no such file or directory\",\"errorType\":\"PathError\"}\nPathError",
          "stoppedAt": "2019-04-22T17:23:07Z"
        }
      ],
      "lastAttemptedResource": "dpt-clogger",
      "lastAttemptedState": "dpt-clogger",
      "lastUpdated": "2019-04-22T17:24:07.382037347Z",
      "namespace": "clever-dev",
      "queue": "development",
      "status": "failed",
      "stoppedAt": "2019-04-22T17:23:07Z",
      "tags": {
        "team": "eng-secure-sync"
      },
      "workflowDefinition": {
        "createdAt": "2019-04-11T23:50:49.122636234Z",
        "defaultTags": {
          "team": "eng-secure-sync"
        },
        "id": "442052ba-64c0-4119-a1eb-4f4ff4dad16a",
        "manager": "step-functions",
        "name": "clogger:back-it-up",
        "stateMachine": {
          "StartAt": "clogger",
          "States": {
            "clogger": {
              "HeartbeatSeconds": "30",
              "Next": "dpt-clogger",
              "Resource": "lambda:clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            },
            "dpt-clogger": {
              "HeartbeatSeconds": "30",
              "Next": "mpt-clogger",
              "Resource": "lambda:dpt-clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            },
            "mpt-clogger": {
              "End": true,
              "HeartbeatSeconds": "30",
              "Resource": "lambda:mpt-clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            }
          },
          "TimeoutSeconds": "259200",
          "Version": "1.0"
        },
        "version": "3"
      }
    },
    "__ttl": "1558545787",
    "_gsi-ca": "2019-04-22T17:23:07.097148937Z",
    "_gsi-wn": "clogger:back-it-up",
    "_gsi-wn-and-resolvedbyuser": "clogger:back-it-up:false",
    "_gsi-wn-and-status": "clogger:back-it-up:failed",
    "id": "c3573673-8e28-47bc-8e43-1073c9c78599"
  }
}
```


I think there may be a concern about hitting the `GetExecutionHistory` more often. This should be fine under normal conditions, but it could be an issue when there is a higher than normal rate of failures.


- [x] Update swagger.yml version
- [x] Run "make generate"
