### PR TITLE
workflow last job info

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -253,6 +253,7 @@
 |**id**  <br>*optional*||string|
 |**input**  <br>*optional*||string|
 |**jobs**  <br>*optional*||< [Job](#job) > array|
+|**lastJob**  <br>*optional*||[Job](#job)|
 |**lastUpdated**  <br>*optional*||string (date-time)|
 |**namespace**  <br>*optional*||string|
 |**output**  <br>*optional*||string|
@@ -323,6 +324,7 @@
 |**createdAt**  <br>*optional*||string (date-time)|
 |**id**  <br>*optional*||string|
 |**input**  <br>*optional*||string|
+|**lastJob**  <br>*optional*||[Job](#job)|
 |**lastUpdated**  <br>*optional*||string (date-time)|
 |**namespace**  <br>*optional*||string|
 |**queue**  <br>*optional*||string|

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.9.6
+*Version* : 0.9.7
 
 
 ### URI scheme

--- a/executor/sfn_events.go
+++ b/executor/sfn_events.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+)
+
+func reverseHistory(events []*sfn.HistoryEvent) []*sfn.HistoryEvent {
+	numEvents := len(events)
+	reversedEvents := make([]*sfn.HistoryEvent, numEvents)
+	for i := 0; i < numEvents; i++ {
+		reversedEvents[i] = events[numEvents-1-i]
+	}
+	return reversedEvents
+}
+
+func isSupportedStateEnteredEvent(evt *sfn.HistoryEvent) bool {
+	switch aws.StringValue(evt.Type) {
+	case sfn.HistoryEventTypeTaskStateEntered,
+		sfn.HistoryEventTypeChoiceStateEntered,
+		sfn.HistoryEventTypeSucceedStateEntered:
+		return true
+	default:
+		return false
+	}
+}

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -365,6 +365,13 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(ctx context.Context, workflo
 	if workflow.Status == models.WorkflowStatusSucceeded || workflow.Status == models.WorkflowStatusCancelled {
 		workflow.ResolvedByUser = true
 	}
+	// Populate the last job within WorkflowSummary on failures so that workflows can be
+	// more easily searched for and bucketed by failure state.
+	if workflow.Status == models.WorkflowStatusFailed {
+		if err := wm.updateWorkflowLastJob(ctx, workflow); err != nil {
+			return err
+		}
+	}
 
 	workflow.Output = aws.StringValue(describeOutput.Output) // use for error or success  (TODO: actually this is only sent for success)
 	return wm.store.UpdateWorkflow(ctx, *workflow)

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -386,46 +386,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 	)
 	jobs := []*models.Job{}
 	eventIDToJob := map[int64]*models.Job{}
-	eventToJob := func(evt *sfn.HistoryEvent) *models.Job {
-		eventID := aws.Int64Value(evt.Id)
-		parentEventID := aws.Int64Value(evt.PreviousEventId)
-		switch *evt.Type {
-		case sfn.HistoryEventTypeExecutionStarted:
-			// very first event for an execution, so there are no jobs yet
-			return nil
-		case sfn.HistoryEventTypePassStateEntered, sfn.HistoryEventTypePassStateExited,
-			sfn.HistoryEventTypeParallelStateEntered, sfn.HistoryEventTypeParallelStateExited,
-			sfn.HistoryEventTypeWaitStateEntered, sfn.HistoryEventTypeWaitStateExited,
-			sfn.HistoryEventTypeFailStateEntered:
-			// only create Jobs for Task, Choice and Succeed states
-			return nil
-		case sfn.HistoryEventTypeTaskStateEntered, sfn.HistoryEventTypeChoiceStateEntered, sfn.HistoryEventTypeSucceedStateEntered:
-			// a job is created when a supported state is entered
-			job := &models.Job{}
-			jobs = append(jobs, job)
-			eventIDToJob[eventID] = job
-			return job
-		case sfn.HistoryEventTypeExecutionAborted:
-			// Execution-level event - update last seen job.
-			return jobs[len(jobs)-1]
-		case sfn.HistoryEventTypeExecutionFailed:
-			// Execution-level event - update last seen job.
-			return jobs[len(jobs)-1]
-		case sfn.HistoryEventTypeExecutionTimedOut:
-			// Execution-level event - update last seen job.
-			return jobs[len(jobs)-1]
-		default:
-			// associate this event with the same job as its parent event
-			job, ok := eventIDToJob[parentEventID]
-			if !ok {
-				// we should investigate these cases, since it means we have a gap in our interpretation of the event history
-				log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
-				return nil
-			}
-			eventIDToJob[eventID] = job
-			return job
-		}
-	}
+	eventToJobFn := newEventToJobFn(execARN, eventIDToJob, &jobs)
 
 	// Setup a context with a timeout of one minute since
 	// we don't want to pull very large workflow histories
@@ -441,7 +402,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 		// 2) set `reverseOrder` to true to get most recent events first
 		// 3) stop paging once we get to to the smallest job ID (aka event ID) that is still pending
 		for _, evt := range historyOutput.Events {
-			job := eventToJob(evt)
+			job := eventToJobFn(evt)
 			if job == nil {
 				continue
 			}
@@ -640,5 +601,53 @@ func causeAndErrorNameFromFailureEvent(evt *sfn.HistoryEvent) (string, string) {
 		return aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Cause), aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Error)
 	default:
 		return "", ""
+	}
+}
+
+func newEventToJobFn(
+	execARN string, eventIDToJob map[int64]*models.Job, jobsPtr *[]*models.Job,
+) func(evt *sfn.HistoryEvent) *models.Job {
+	return func(evt *sfn.HistoryEvent) *models.Job {
+		jobs := *jobsPtr
+		eventID := aws.Int64Value(evt.Id)
+		parentEventID := aws.Int64Value(evt.PreviousEventId)
+		switch *evt.Type {
+		case sfn.HistoryEventTypeExecutionStarted:
+			// very first event for an execution, so there are no jobs yet
+			return nil
+		case sfn.HistoryEventTypePassStateEntered, sfn.HistoryEventTypePassStateExited,
+			sfn.HistoryEventTypeParallelStateEntered, sfn.HistoryEventTypeParallelStateExited,
+			sfn.HistoryEventTypeWaitStateEntered, sfn.HistoryEventTypeWaitStateExited,
+			sfn.HistoryEventTypeFailStateEntered:
+			// only create Jobs for Task, Choice and Succeed states
+			return nil
+		case sfn.HistoryEventTypeTaskStateEntered,
+			sfn.HistoryEventTypeChoiceStateEntered,
+			sfn.HistoryEventTypeSucceedStateEntered:
+			// a job is created when a supported state is entered
+			job := &models.Job{}
+			*jobsPtr = append(jobs, job)
+			eventIDToJob[eventID] = job
+			return job
+		case sfn.HistoryEventTypeExecutionAborted:
+			// Execution-level event - update last seen job.
+			return jobs[len(jobs)-1]
+		case sfn.HistoryEventTypeExecutionFailed:
+			// Execution-level event - update last seen job.
+			return jobs[len(jobs)-1]
+		case sfn.HistoryEventTypeExecutionTimedOut:
+			// Execution-level event - update last seen job.
+			return jobs[len(jobs)-1]
+		default:
+			// associate this event with the same job as its parent event
+			job, ok := eventIDToJob[parentEventID]
+			if !ok {
+				// we should investigate these cases, since it means we have a gap in our interpretation of the event history
+				log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
+				return nil
+			}
+			eventIDToJob[eventID] = job
+			return job
+		}
 	}
 }

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -1095,6 +1095,25 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 	assertWorkflowTimedOutJobData(t, workflow.LastJob)
 }
 
+func TestReverseHistory(t *testing.T) {
+	events := []*sfn.HistoryEvent{
+		jobCreatedEvent,
+		jobScheduledEvent,
+		jobStartedEvent,
+		jobTimedOutEvent,
+		jobTimedOutWorkflowFailedEvent,
+	}
+	reversedEvents := []*sfn.HistoryEvent{
+		jobTimedOutWorkflowFailedEvent,
+		jobTimedOutEvent,
+		jobStartedEvent,
+		jobScheduledEvent,
+		jobCreatedEvent,
+	}
+
+	assert.Equal(t, reversedEvents, reverseHistory(events))
+}
+
 func newSFNManagerTestController(t *testing.T) *sfnManagerTestController {
 	mockController := gomock.NewController(t)
 	mockSFNAPI := mocks.NewMockSFNAPI(mockController)
@@ -1131,13 +1150,4 @@ func (c *sfnManagerTestController) updateWorkflow(ctx context.Context, t *testin
 
 func (c *sfnManagerTestController) tearDown() {
 	c.mockController.Finish()
-}
-
-func reverseHistory(events []*sfn.HistoryEvent) []*sfn.HistoryEvent {
-	numEvents := len(events)
-	reversedEvents := make([]*sfn.HistoryEvent, numEvents)
-	for i := 0; i < numEvents; i++ {
-		reversedEvents[i] = events[numEvents-1-i]
-	}
-	return reversedEvents
 }

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -572,6 +572,13 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 	assert.WithinDuration(
 		t, jobFailedEventTimestamp, time.Time(workflow.Jobs[0].StoppedAt), 1*time.Second,
 	)
+	require.NotNil(t, workflow.LastJob)
+	assertBasicJobData(t, workflow.LastJob)
+	assert.Equal(t, models.JobStatusFailed, workflow.LastJob.Status)
+	assert.Equal(t, "line4\nline5\nline6", workflow.LastJob.StatusReason)
+	assert.WithinDuration(
+		t, jobFailedEventTimestamp, time.Time(workflow.LastJob.StoppedAt), 1*time.Second,
+	)
 }
 
 func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
@@ -636,6 +643,13 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 	assert.Equal(t, "State resource does not exist", workflow.Jobs[0].StatusReason)
 	assert.WithinDuration(
 		t, jobFailedEventTimestamp, time.Time(workflow.Jobs[0].StoppedAt), 1*time.Second,
+	)
+	require.NotNil(t, workflow.LastJob)
+	assertBasicJobData(t, workflow.LastJob)
+	assert.Equal(t, models.JobStatusFailed, workflow.LastJob.Status)
+	assert.Equal(t, "State resource does not exist", workflow.LastJob.StatusReason)
+	assert.WithinDuration(
+		t, jobFailedEventTimestamp, time.Time(workflow.LastJob.StoppedAt), 1*time.Second,
 	)
 }
 
@@ -708,6 +722,7 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
 	assertSucceededJobData(t, workflow.Jobs[0])
+	require.Nil(t, workflow.LastJob)
 }
 
 var jobAbortedEventTimestamp = jobSucceededEventTimestamp.Add(5 * time.Minute)
@@ -901,6 +916,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundStopRetry(t *testing.T) {
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
 	require.Len(t, workflow.Jobs, 0)
+	require.Nil(t, workflow.LastJob)
 }
 
 var jobScheduledEventTimestamp = jobCreatedEventTimestamp.Add(1 * time.Minute)
@@ -1003,6 +1019,9 @@ func TestUpdateWorkflowStatusJobTimedOut(t *testing.T) {
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
 	assertTimedOutJobData(t, workflow.Jobs[0])
+	require.NotNil(t, workflow.LastJob)
+	assertBasicJobData(t, workflow.LastJob)
+	assertTimedOutJobData(t, workflow.LastJob)
 }
 
 var workflowTimedOutEventTimestamp = jobCreatedEventTimestamp.Add(10 * time.Minute)
@@ -1074,6 +1093,9 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
 	assertWorkflowTimedOutJobData(t, workflow.Jobs[0])
+	require.NotNil(t, workflow.LastJob)
+	assertBasicJobData(t, workflow.LastJob)
+	assertWorkflowTimedOutJobData(t, workflow.LastJob)
 }
 
 func newSFNManagerTestController(t *testing.T) *sfnManagerTestController {

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -1087,9 +1087,6 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
-	// TODO: this line below is not testing anything. Verify what needs to go in this assertion
-	assert.Equal(t, "Workflow timed out", resources.StatusReasonWorkflowTimedOut)
-	assert.Equal(t, resources.StatusReasonWorkflowTimedOut, workflow.StatusReason)
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
 	assertWorkflowTimedOutJobData(t, workflow.Jobs[0])

--- a/gen-go/models/workflow_summary.go
+++ b/gen-go/models/workflow_summary.go
@@ -25,6 +25,9 @@ type WorkflowSummary struct {
 	// input
 	Input string `json:"input,omitempty"`
 
+	// last job
+	LastJob *Job `json:"lastJob,omitempty"`
+
 	// last updated
 	LastUpdated strfmt.DateTime `json:"lastUpdated,omitempty"`
 
@@ -60,6 +63,11 @@ type WorkflowSummary struct {
 func (m *WorkflowSummary) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateLastJob(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
 	if err := m.validateRetries(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -78,6 +86,25 @@ func (m *WorkflowSummary) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *WorkflowSummary) validateLastJob(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.LastJob) { // not required
+		return nil
+	}
+
+	if m.LastJob != nil {
+
+		if err := m.LastJob.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("lastJob")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.9.6
+  version: 0.9.7
   x-npm-package: workflow-manager
 schemes:
   - http

--- a/swagger.yml
+++ b/swagger.yml
@@ -478,6 +478,8 @@ definitions:
         description: "tags: object with key-value pairs; keys and values should be strings"
         additionalProperties:
           type: object
+      lastJob:
+        $ref: '#/definitions/Job'
 
   WorkflowStatus:
     type: string


### PR DESCRIPTION
The hubble/repairs page is slow to load when there are a large number of active workflows. The reason for the slowness is that it iterates through every active workflow and loads the full workflow history for each one. We are in the process of modifying Hubble to query Elasticsearch for active and recent workflows instead of using workflow-manager, and we are also exploring the possibility of querying Elasticsearch for failed workflows. This change introduces a new method that fetches the most recent events in the state machine's execution history, and stores the last Job info in the `WorkflowSummary`. The new method shares a lot of logic with https://github.com/Clever/workflow-manager/blob/f0f8abee201526cbe7f51ee93fcb41dbf6d0cd27/executor/workflow_manager_sfn.go#L372, and the main difference that it doesn't page through the entire execution history to fill out the Jobs array and instead just looks at the most recent events. Some of the code from `UpdateWorkflowHistory` is refactored into separate functions so that they can be used in the new `updateWorkflowLastJob` method. 

Here's an earlier draft at this that would fill in the entire jobs array https://github.com/Clever/workflow-manager/pull/170. The downside of that approach is that it would call `GetExecutionHistory` for each failed workflow update, and that endpoint has a relatively low rate limit.

Below is an example workflow that I created with `lastJob` populated
```
[renatoprime@Renatos-MacBook-Pro workflow-manager (SYNC-1172-workflow-last-attempted-state-v2)]$ curl https://vpc-workflows-dev-2nfzpvqce62oumm6zcnjaipife.us-west-1.es.amazonaws.com/clever-dev-workflow-manager-dev-v3-workflows/default/fa275130-4be8-42be-85ac-7a6cdf378268 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2055  100  2055    0     0  17471      0 --:--:-- --:--:-- --:--:-- 17415
{
  "_index": "clever-dev-workflow-manager-dev-v3-workflows",
  "_type": "default",
  "_id": "fa275130-4be8-42be-85ac-7a6cdf378268",
  "_version": 3,
  "found": true,
  "_source": {
    "Workflow": {
      "createdAt": "2019-04-23T15:00:53.795429Z",
      "id": "fa275130-4be8-42be-85ac-7a6cdf378268",
      "input": "{\"uh\":\"boo\"}",
      "lastJob": {
        "createdAt": "2019-04-23T15:00:54Z",
        "id": "2",
        "input": "{\"_EXECUTION_NAME\":\"fa275130-4be8-42be-85ac-7a6cdf378268\",\"uh\":\"boo\"}",
        "startedAt": "2019-04-23T15:00:54Z",
        "state": "clogger",
        "stateResource": {
          "lastUpdated": "2019-04-23T15:00:54Z",
          "name": "clogger",
          "namespace": "clever-dev",
          "type": "LambdaFunctionARN"
        },
        "status": "failed",
        "statusReason": "{\"errorMessage\":\"🐖  🐖  🐖  🐖  🐖  🐖\",\"errorType\":\"errorString\"}\nerrorString",
        "stoppedAt": "2019-04-23T15:00:54Z"
      },
      "lastUpdated": "2019-04-23T15:01:54.667503Z",
      "namespace": "clever-dev",
      "queue": "default",
      "status": "failed",
      "stoppedAt": "2019-04-23T15:00:54Z",
      "tags": {
        "team": "eng-secure-sync"
      },
      "workflowDefinition": {
        "createdAt": "2019-04-11T23:50:49.122636234Z",
        "defaultTags": {
          "team": "eng-secure-sync"
        },
        "id": "442052ba-64c0-4119-a1eb-4f4ff4dad16a",
        "manager": "step-functions",
        "name": "clogger:back-it-up",
        "stateMachine": {
          "StartAt": "clogger",
          "States": {
            "clogger": {
              "HeartbeatSeconds": "30",
              "Next": "dpt-clogger",
              "Resource": "lambda:clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            },
            "dpt-clogger": {
              "HeartbeatSeconds": "30",
              "Next": "mpt-clogger",
              "Resource": "lambda:dpt-clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            },
            "mpt-clogger": {
              "End": true,
              "HeartbeatSeconds": "30",
              "Resource": "lambda:mpt-clogger",
              "Retry": [
                {
                  "ErrorEquals": [
                    "States.ALL"
                  ],
                  "MaxAttempts": "0"
                }
              ],
              "TimeoutSeconds": "7200",
              "Type": "Task"
            }
          },
          "TimeoutSeconds": "259200",
          "Version": "1.0"
        },
        "version": "3"
      }
    },
    "__ttl": "1558623653",
    "_gsi-ca": "2019-04-23T15:00:53.795429Z",
    "_gsi-wn": "clogger:back-it-up",
    "_gsi-wn-and-resolvedbyuser": "clogger:back-it-up:false",
    "_gsi-wn-and-status": "clogger:back-it-up:failed",
    "id": "fa275130-4be8-42be-85ac-7a6cdf378268"
  }
}
```

- [x] Update swagger.yml version
- [x] Run "make generate"
