### PR TITLE
add workflow id to log context for request-finished

### DIFF
--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -223,7 +223,7 @@ func TestCreateWorkflow(t *testing.T) {
 			}).
 			Return(&sqs.DeleteMessageOutput{}, nil)
 
-		wfID, err := updatePendingWorkflow(context.TODO(), msg, c.manager, c.store, c.mockSQSAPI, "")
+		wfID, err := updatePendingWorkflow(ctx, msg, c.manager, c.store, c.mockSQSAPI, "")
 		assert.Nil(t, err)
 		assert.Equal(t, workflow.ID, wfID)
 	})


### PR DESCRIPTION
trying to dig into failed `startWorkflow` requests for specific workflow IDs, so adding the ID to request-finished logs