### PR TITLE
log sqs sendMessage errors when creating pending workflows

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -71,11 +71,19 @@ func PollForPendingWorkflowsAndUpdateStore(ctx context.Context, wm WorkflowManag
 const updateLoopDelay = 60
 
 func createPendingWorkflow(ctx context.Context, workflowID string, sqsapi sqsiface.SQSAPI, sqsQueueURL string) error {
-	_, err := sqsapi.SendMessageWithContext(ctx, &sqs.SendMessageInput{
+	message, err := sqsapi.SendMessageWithContext(ctx, &sqs.SendMessageInput{
 		MessageBody:  aws.String(workflowID),
 		QueueUrl:     aws.String(sqsQueueURL),
 		DelaySeconds: aws.Int64(updateLoopDelay),
 	})
+	if err != nil {
+		log.ErrorD("sqs-send-message",
+			logger.M{
+				"error":       err.Error(),
+				"workflow-id": workflowID,
+				"message-id":  aws.StringValue(message.MessageId),
+			})
+	}
 	return err
 }
 


### PR DESCRIPTION
Log any errors that occur when attempting to put new workflows in the update loop. This change is part of an investigation into mysterious 503 errors which happen within `CreateWorkflow`. The errors seem to happen with workflows that never get updated which supports @meliaj 's theory that they are the root cause of the forever queued workflows.

- [ ] Update swagger.yml version
- [ ] Run "make generate"
