### PR TITLE
bump execution history events per page

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	maxFailureReasonLines   = 3
+	executionEventsPerPage  = 200
 	sfncliCommandTerminated = "sfncli.CommandTerminated"
 )
 
@@ -402,6 +403,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 	eventIDToJob := map[int64]*models.Job{}
 	if err := wm.sfnapi.GetExecutionHistoryPagesWithContext(ctx, &sfn.GetExecutionHistoryInput{
 		ExecutionArn: aws.String(execARN),
+		MaxResults:   aws.Int64(executionEventsPerPage),
 	}, func(historyOutput *sfn.GetExecutionHistoryOutput, lastPage bool) bool {
 		// NOTE: if pulling the entire execution history becomes infeasible, we can:
 		// 1) limit the results with `maxResults`

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -488,6 +488,7 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -543,6 +544,7 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -616,6 +618,7 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -702,6 +705,7 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -764,6 +768,7 @@ func TestUpdateWorkflowStatusJobCancelled(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -808,6 +813,7 @@ func TestUpdateWorkflowStatusWorkflowCancelledAfterJobSucceeded(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -861,6 +867,7 @@ func TestUpdateWorkflowStatusExecutionNotFoundRetry(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -994,6 +1001,7 @@ func TestUpdateWorkflowStatusJobTimedOut(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,
@@ -1065,6 +1073,7 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 	c.mockSFNAPI.EXPECT().
 		GetExecutionHistoryPagesWithContext(gomock.Any(), &sfn.GetExecutionHistoryInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
+			MaxResults:   aws.Int64(executionEventsPerPage),
 		}, gomock.Any()).
 		Do(func(
 			ctx aws.Context,


### PR DESCRIPTION
- [ ] Update swagger.yml version
- [ ] Run "make generate"

This is sort of a follow up to https://github.com/Clever/workflow-manager/pull/179. There are many workflows that create over 100 events, so I think we could reduce the number of calls to `GetExecutionHistory` if we bump the results per page from the default of 100 to 200.

https://docs.aws.amazon.com/step-functions/latest/apireference/API_GetExecutionHistory.html#API_GetExecutionHistory_RequestSyntax

I tested this in staging by looking at some workflow histories.  