### PR TITLE
optionally omit execution history + use lastJob input when rerunning workflows

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.10.0
+*Version* : 0.11.0
 
 
 ### URI scheme

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -295,9 +295,10 @@ GET /workflows/{workflowID}
 
 #### Parameters
 
-|Type|Name|Schema|
-|---|---|---|
-|**Path**|**workflowID**  <br>*required*|string|
+|Type|Name|Description|Schema|Default|
+|---|---|---|---|---|
+|**Path**|**workflowID**  <br>*required*||string||
+|**Query**|**omitExecutionHistory**  <br>*optional*|Skips fetching the full execution history, and omits the jobs array.|boolean|`"false"`|
 
 
 #### Responses

--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -430,7 +430,8 @@ func (e *Embedded) CancelWorkflow(ctx context.Context, i *models.CancelWorkflowI
 }
 
 // GetWorkflowByID ...
-func (e *Embedded) GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error) {
+func (e *Embedded) GetWorkflowByID(ctx context.Context, i *models.GetWorkflowByIDInput) (*models.Workflow, error) {
+	workflowID := i.WorkflowID
 	widParts, err := parseWorkflowID(workflowID)
 	if err != nil {
 		return nil, err

--- a/embedded/example/example.go
+++ b/embedded/example/example.go
@@ -81,7 +81,7 @@ func main() {
 
 	for {
 		time.Sleep(2 * time.Second)
-		wf, err := client.GetWorkflowByID(ctx, wf.ID)
+		wf, err := client.GetWorkflowByID(ctx, &models.GetWorkflowByIDInput{WorkflowID: wf.ID})
 		if err != nil {
 			fmt.Println("Oops, err", err)
 			break

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -1659,11 +1659,11 @@ func (c *WagClient) doCancelWorkflowRequest(ctx context.Context, req *http.Reque
 // 404: *models.NotFound
 // 500: *models.InternalError
 // default: client side HTTP errors, for example: context.DeadlineExceeded.
-func (c *WagClient) GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error) {
+func (c *WagClient) GetWorkflowByID(ctx context.Context, i *models.GetWorkflowByIDInput) (*models.Workflow, error) {
 	headers := make(map[string]string)
 
 	var body []byte
-	path, err := models.GetWorkflowByIDInputPath(workflowID)
+	path, err := i.Path()
 
 	if err != nil {
 		return nil, err

--- a/gen-go/client/interface.go
+++ b/gen-go/client/interface.go
@@ -132,7 +132,7 @@ type Client interface {
 	// 404: *models.NotFound
 	// 500: *models.InternalError
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
-	GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error)
+	GetWorkflowByID(ctx context.Context, i *models.GetWorkflowByIDInput) (*models.Workflow, error)
 
 	// ResumeWorkflowByID makes a POST request to /workflows/{workflowID}
 	//

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -383,22 +383,23 @@ func (i CancelWorkflowInput) Path() (string, error) {
 
 // GetWorkflowByIDInput holds the input parameters for a getWorkflowByID operation.
 type GetWorkflowByIDInput struct {
-	WorkflowID string
+	WorkflowID           string
+	OmitExecutionHistory *bool
 }
 
-// ValidateGetWorkflowByIDInput returns an error if the input parameter doesn't
-// satisfy the requirements in the swagger yml file.
-func ValidateGetWorkflowByIDInput(workflowID string) error {
+// Validate returns an error if any of the GetWorkflowByIDInput parameters don't satisfy the
+// requirements from the swagger yml file.
+func (i GetWorkflowByIDInput) Validate() error {
 
 	return nil
 }
 
-// GetWorkflowByIDInputPath returns the URI path for the input.
-func GetWorkflowByIDInputPath(workflowID string) (string, error) {
+// Path returns the URI path for the input.
+func (i GetWorkflowByIDInput) Path() (string, error) {
 	path := "/workflows/{workflowID}"
 	urlVals := url.Values{}
 
-	pathworkflowID := workflowID
+	pathworkflowID := i.WorkflowID
 	if pathworkflowID == "" {
 		err := fmt.Errorf("workflowID cannot be empty because it's a path parameter")
 		if err != nil {
@@ -406,6 +407,10 @@ func GetWorkflowByIDInputPath(workflowID string) (string, error) {
 		}
 	}
 	path = strings.Replace(path, "{workflowID}", pathworkflowID, -1)
+
+	if i.OmitExecutionHistory != nil {
+		urlVals.Add("omitExecutionHistory", strconv.FormatBool(*i.OmitExecutionHistory))
+	}
 
 	return path + "?" + urlVals.Encode(), nil
 }

--- a/gen-go/server/interface.go
+++ b/gen-go/server/interface.go
@@ -131,7 +131,7 @@ type Controller interface {
 	// 404: *models.NotFound
 	// 500: *models.InternalError
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
-	GetWorkflowByID(ctx context.Context, workflowID string) (*models.Workflow, error)
+	GetWorkflowByID(ctx context.Context, i *models.GetWorkflowByIDInput) (*models.Workflow, error)
 
 	// ResumeWorkflowByID handles POST requests to /workflows/{workflowID}
 	//

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -22,7 +22,7 @@ workflow-manager client library.
             * [.getWorkflowsIter(params, [options])](#module_workflow-manager--WorkflowManager+getWorkflowsIter) ⇒ <code>Object</code> &#124; <code>function</code> &#124; <code>function</code> &#124; <code>function</code>
             * [.startWorkflow(StartWorkflowRequest, [options], [cb])](#module_workflow-manager--WorkflowManager+startWorkflow) ⇒ <code>Promise</code>
             * [.CancelWorkflow(params, [options], [cb])](#module_workflow-manager--WorkflowManager+CancelWorkflow) ⇒ <code>Promise</code>
-            * [.getWorkflowByID(workflowID, [options], [cb])](#module_workflow-manager--WorkflowManager+getWorkflowByID) ⇒ <code>Promise</code>
+            * [.getWorkflowByID(params, [options], [cb])](#module_workflow-manager--WorkflowManager+getWorkflowByID) ⇒ <code>Promise</code>
             * [.resumeWorkflowByID(params, [options], [cb])](#module_workflow-manager--WorkflowManager+resumeWorkflowByID) ⇒ <code>Promise</code>
             * [.resolveWorkflowByID(workflowID, [options], [cb])](#module_workflow-manager--WorkflowManager+resolveWorkflowByID) ⇒ <code>Promise</code>
         * _static_
@@ -354,7 +354,7 @@ Get the latest versions of all available WorkflowDefinitions
 
 <a name="module_workflow-manager--WorkflowManager+getWorkflowByID"></a>
 
-#### workflowManager.getWorkflowByID(workflowID, [options], [cb]) ⇒ <code>Promise</code>
+#### workflowManager.getWorkflowByID(params, [options], [cb]) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[WorkflowManager](#exp_module_workflow-manager--WorkflowManager)</code>  
 **Fulfill**: <code>Object</code>  
 **Reject**: <code>[BadRequest](#module_workflow-manager--WorkflowManager.Errors.BadRequest)</code>  
@@ -364,7 +364,9 @@ Get the latest versions of all available WorkflowDefinitions
 
 | Param | Type | Description |
 | --- | --- | --- |
-| workflowID | <code>string</code> |  |
+| params | <code>Object</code> |  |
+| params.workflowID | <code>string</code> |  |
+| [params.omitExecutionHistory] | <code>boolean</code> | Skips fetching the full execution history, and omits the jobs array. |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
 | [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -2004,7 +2004,9 @@ class WorkflowManager {
   }
 
   /**
-   * @param {string} workflowID
+   * @param {Object} params
+   * @param {string} params.workflowID
+   * @param {boolean} [params.omitExecutionHistory] - Skips fetching the full execution history, and omits the jobs array.
    * @param {object} [options]
    * @param {number} [options.timeout] - A request specific timeout
    * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
@@ -2017,7 +2019,7 @@ class WorkflowManager {
    * @reject {module:workflow-manager.Errors.InternalError}
    * @reject {Error}
    */
-  getWorkflowByID(workflowID, options, cb) {
+  getWorkflowByID(params, options, cb) {
     let callback = cb;
     if (!cb && typeof options === "function") {
       callback = options;
@@ -2025,10 +2027,7 @@ class WorkflowManager {
     return applyCallback(this._hystrixCommand.execute(this._getWorkflowByID, arguments), callback);
   }
 
-  _getWorkflowByID(workflowID, options, cb) {
-    const params = {};
-    params["workflowID"] = workflowID;
-
+  _getWorkflowByID(params, options, cb) {
     if (!cb && typeof options === "function") {
       options = undefined;
     }
@@ -2049,6 +2048,10 @@ class WorkflowManager {
       }
 
       const query = {};
+      if (typeof params.omitExecutionHistory !== "undefined") {
+        query["omitExecutionHistory"] = params.omitExecutionHistory;
+      }
+  
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -212,6 +212,12 @@ paths:
           in: path
           type: string
           required: true
+        - name: omitExecutionHistory
+          description: Skips fetching the full execution history, and omits the jobs array.
+          in: query
+          type: boolean
+          required: false
+          default: false
       responses:
         200:
           description: Workflow

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.10.0
+  version: 0.11.0
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
This pull request contains two changes:
- Introduce `omitExecutionHistory` as an optional query parameter for the `GetWorkflowByID` API endpoint.
- Allow the `ResumeWorkflowByID` endpoint to use the input payload from `lastJob` when available. 

Returning a workflow object with its `jobs` array populated requires querying the `GetExecutionHistory` endpoint via the stepfunctions API which is a relatively expensive operation. Sometimes workflows get stuck in a loop and accumulate so many execution events that the `GetExecutionHistory` calls can time out causing the request to fail. The `omitExecutionHistory` allows us to fetch the workflow summary when the execution history is long without failing, and it allows us to fetch workflows more efficiently when the jobs array isn't needed. 
Calling the `GetWorkflowByID` endpoint with `omitExecutionHistory` set to `true` will return the workflow object without a jobs array.

`ResumeWorkflowByID` will now use the input from `lastJob` when available instead of only searching through the jobs array. `lastJob` is populated for failed workflows, and it populated automatically when the workflow update loop calls `UpdateWorkflowSummary`. Prior to this change, the only way to rerun a workflow was by first making a separate `GetWorkflowByID` call to populate the jobs array. We almost always want to rerun workflows from the state in which they failed, and this change allows workflows to be rerun without needing the full execution history. It's still possible to rerun a workflow from an earlier state in the state machine, but that requires pre-populating the jobs array as before.

Now it's possible to rerun a workflow even if its execution history cannot be loaded.

I tested this is staging by querying `GetWorkflowByID` with `omitExecutionHistory`, and I also tested `ResumeWorkflowByID` through the js client. 

I reran 1000 workflows with and without these changes, and I've included screenshots of the dynamodb metrics below.

Rerunning workflows without these changes results in dynamodb throttling.
<img width="1393" alt="Screen Shot 2019-08-08 at 8 13 48 AM" src="https://user-images.githubusercontent.com/32328921/62744536-cedc8880-b9fb-11e9-8df1-4755532182a5.png">

With these changes, fewer dynamodb writes are consumed. 
<img width="1418" alt="Screen Shot 2019-08-08 at 1 36 53 PM" src="https://user-images.githubusercontent.com/32328921/62744535-cedc8880-b9fb-11e9-9f17-2a3f735ac5dc.png">



- [x] Update swagger.yml version
- [x] Run "make generate"
