### PR TITLE
Use the input from lastJob when it's available

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -360,31 +360,55 @@ func (h Handler) ResumeWorkflowByID(ctx context.Context, input *models.ResumeWor
 	if !resources.WorkflowIsDone(&workflow) {
 		return &models.Workflow{}, fmt.Errorf("Workflow %s active: %s", workflow.ID, workflow.Status)
 	}
+	isDone, err := descendantsAreDone(ctx, h.store, workflow)
+	if err != nil {
+		return &models.Workflow{}, fmt.Errorf("Failed to check descendant workflows: %s", err)
+	}
+	if !isDone {
+		return &models.Workflow{}, fmt.Errorf("Workflow %s has active descendants: %s", workflow.ID, workflow.Status)
+	}
 	if _, ok := workflow.WorkflowDefinition.StateMachine.States[input.Overrides.StartAt]; !ok {
 		return &models.Workflow{}, fmt.Errorf("Invalid StartAt state %s", input.Overrides.StartAt)
 	}
 
-	// find the input to the StartAt state
-	effectiveInput := ""
-	for _, job := range workflow.Jobs {
-		if job.State == input.Overrides.StartAt {
-			// if job was never started then we should probably not trust the input
-			if job.Status == models.JobStatusAbortedDepsFailed ||
-				job.Status == models.JobStatusQueued ||
-				job.Status == models.JobStatusWaitingForDeps ||
-				job.Status == models.JobStatusCreated {
-
-				return &models.Workflow{},
-					fmt.Errorf("Job %s for StartAt %s was not started for Workflow: %s. Could not infer input",
-						job.ID, job.State, workflow.ID)
+	// Find the job that ran for the StartAt state so that its input can be used for the new workflow.
+	// Try to use lastJob if it's available and if we want to start the new workflow from that state,
+	// otherwise load the full execution history and search through it to find the desired input.
+	var originalJob *models.Job
+	if workflow.LastJob != nil && input.Overrides.StartAt == workflow.LastJob.State {
+		originalJob = workflow.LastJob
+	} else {
+		if workflow.Jobs == nil {
+			if err := h.manager.UpdateWorkflowHistory(ctx, &workflow); err != nil {
+				return &models.Workflow{}, err
 			}
+			updatedWorkflow, err := h.store.GetWorkflowByID(ctx, input.WorkflowID)
+			if err != nil {
+				return &models.Workflow{}, err
+			}
+			workflow = updatedWorkflow
+		}
 
-			effectiveInput = job.Input
-			break
+		for _, job := range workflow.Jobs {
+			if job.State == input.Overrides.StartAt {
+				originalJob = job
+				break
+			}
 		}
 	}
 
-	return h.manager.RetryWorkflow(ctx, workflow, input.Overrides.StartAt, effectiveInput)
+	if originalJob == nil {
+		return &models.Workflow{}, fmt.Errorf("No job found for StartAt %s", input.Overrides.StartAt)
+	}
+
+	// if job was never started then we should probably not trust the input
+	if !hasJobStarted(originalJob.Status) {
+		return &models.Workflow{},
+			fmt.Errorf("Job %s for StartAt %s was not started for Workflow: %s. Could not infer input",
+				originalJob.ID, originalJob.State, workflow.ID)
+	}
+
+	return h.manager.RetryWorkflow(ctx, workflow, input.Overrides.StartAt, originalJob.Input)
 }
 
 // ResolveWorkflowByID sets a workflow's ResolvedByUser to true if it is currently false.
@@ -430,6 +454,13 @@ func newWorkflowDefinitionFromRequest(req models.NewWorkflowDefinitionRequest) (
 	return resources.NewWorkflowDefinition(req.Name, req.Manager, req.StateMachine, req.DefaultTags)
 }
 
+func hasJobStarted(status models.JobStatus) bool {
+	return !(status == models.JobStatusAbortedDepsFailed ||
+		status == models.JobStatusQueued ||
+		status == models.JobStatusWaitingForDeps ||
+		status == models.JobStatusCreated)
+}
+
 // validateTagsMap ensures that all tags values are strings
 func validateTagsMap(apiTags map[string]interface{}) error {
 	for _, val := range apiTags {
@@ -442,4 +473,25 @@ func validateTagsMap(apiTags map[string]interface{}) error {
 
 func epochMillis(t time.Time) int {
 	return int(t.UnixNano() / int64(time.Millisecond))
+}
+
+// descendantsAreDone checks a workflow's descendants for any active workflows.
+func descendantsAreDone(ctx context.Context, s store.Store, workflow models.Workflow) (bool, error) {
+	for _, childID := range workflow.Retries {
+		childWorkflow, err := s.GetWorkflowByID(ctx, childID)
+		if err != nil {
+			return false, err
+		}
+		if !resources.WorkflowIsDone(&childWorkflow) {
+			return false, nil
+		}
+		areDescendantsDone, err := descendantsAreDone(ctx, s, childWorkflow)
+		if err != nil {
+			return false, err
+		}
+		if !areDescendantsDone {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/handler.go
+++ b/handler.go
@@ -374,6 +374,11 @@ func (h Handler) ResumeWorkflowByID(ctx context.Context, input *models.ResumeWor
 	// Find the job that ran for the StartAt state so that its input can be used for the new workflow.
 	// Try to use lastJob if it's available and if we want to start the new workflow from that state,
 	// otherwise load the full execution history and search through it to find the desired input.
+	// Note: getting the workflow's execution history involves making expensive API calls to the
+	// stepfunctions GetExecutionHistory endpoint. GetWorkflowByID can be called beforehand to avoid
+	// the workflow.Jobs == nil path.
+	// Clients may wish to increase the timeout from the global default to handle workflows with long
+	// execution histories.
 	var originalJob *models.Job
 	if workflow.LastJob != nil && input.Overrides.StartAt == workflow.LastJob.State {
 		originalJob = workflow.LastJob


### PR DESCRIPTION
This is a second attempt at https://github.com/Clever/workflow-manager/pull/208

Given a workflow ID and the name of a workflow state to start from, `resumeWorkflowByID` creates a new workflow that begins execution from the `StartAt` state and uses the input to that state from the original workflow. The new workflow is then linked to the original as a retry. The way that `resumeWorkflowByID` finds the workflow input that it needs is by searching through the original workflow's `jobs` array. It relies on `jobs` being populated ahead of time, however `jobs` is not populated automatically like other workflow fields are. In order for `jobs` to exist for a workflow, `getWorkflowByID` must be called before `resumeWorkflowByID` is called, otherwise `jobs` will be `nil` and `resumeWorkflowByID` will error. 

This pull request helps solve a couple of issues: 
- A workflow with an extremely long execution history cannot be rerun because its `jobs` array can't be populated.
- Rerunning many workflows at the same time can result in dynamo db throttling because of the needed `getWorkflowByID` calls.

With this change, `resumeWorkflowByID` uses the workflow input from `lastJob` when possible. If `lastJob` is not available, then it will load the full `jobs` array and search through it to find the input that it needs. `resumeWorkflowByID` is almost always used to rerun a workflow from the state in which it failed, so in practice the input will be taken from `lastJob` a vast majority of the time. By using `lastJob` instead of `jobs`, we avoid needing to populate `jobs` and we avoid lots of dynamodb writes.

I tested this by running workflow-manager locally and rerunning failed workflows.


- [ ] Update swagger.yml version
- [ ] Run "make generate"
