### PR TITLE
Workflow Manager Tracing

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.10.1
+*Version* : 0.11.0
 
 
 ### URI scheme

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -116,7 +116,7 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	}
 
 	wfID := *m.Body
-	span.SetTag("wf-id", wfID)
+	span.SetTag("workflow-id", wfID)
 	wf, err := thestore.GetWorkflowByID(ctx, wfID)
 	if err != nil {
 		if _, ok := err.(models.NotFound); ok {

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -227,7 +227,7 @@ func (wm *SFNWorkflowManager) CreateWorkflow(ctx context.Context, wd models.Work
 	// i.e. execution was started but we failed to save workflow
 	// If we fail starting the execution, we can resolve this out of band (TODO: should support cancelling)
 	workflow := resources.NewWorkflow(&wd, input, namespace, queue, mergedTags)
-	logger.FromContext(ctx).AddContext("wf-id", workflow.ID)
+	logger.FromContext(ctx).AddContext("workflow-id", workflow.ID)
 	if err := wm.store.SaveWorkflow(ctx, *workflow); err != nil {
 		return nil, err
 	}

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -153,14 +153,14 @@ func TestCreateWorkflow(t *testing.T) {
 			c.workflowDefinition.StateMachine.StartAt,
 		)
 		c.mockSFNAPI.EXPECT().
-			DescribeStateMachine(&sfn.DescribeStateMachineInput{
+			DescribeStateMachineWithContext(gomock.Any(), &sfn.DescribeStateMachineInput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}).
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
 		c.mockSFNAPI.EXPECT().
-			StartExecution(gomock.Any()).
+			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
 		c.mockSQSAPI.EXPECT().
 			SendMessageWithContext(gomock.Any(), gomock.Any()).
@@ -240,14 +240,14 @@ func TestCreateWorkflow(t *testing.T) {
 			c.workflowDefinition.StateMachine.StartAt,
 		)
 		c.mockSFNAPI.EXPECT().
-			DescribeStateMachine(&sfn.DescribeStateMachineInput{
+			DescribeStateMachineWithContext(gomock.Any(), &sfn.DescribeStateMachineInput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}).
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
 		c.mockSFNAPI.EXPECT().
-			StartExecution(gomock.Any()).
+			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
 		c.mockSQSAPI.EXPECT().
 			SendMessageWithContext(gomock.Any(), gomock.Any()).
@@ -291,14 +291,14 @@ func TestCreateWorkflow(t *testing.T) {
 		)
 		awsError := awserr.New("test", "test", errors.New(""))
 		c.mockSFNAPI.EXPECT().
-			DescribeStateMachine(&sfn.DescribeStateMachineInput{
+			DescribeStateMachineWithContext(gomock.Any(), &sfn.DescribeStateMachineInput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}).
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
 		c.mockSFNAPI.EXPECT().
-			StartExecution(gomock.Any()).
+			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(nil, awsError)
 
 		workflow, err := c.manager.CreateWorkflow(ctx, *c.workflowDefinition,
@@ -331,14 +331,14 @@ func TestRetryWorkflow(t *testing.T) {
 			c.workflowDefinition.StateMachine.StartAt,
 		)
 		c.mockSFNAPI.EXPECT().
-			DescribeStateMachine(&sfn.DescribeStateMachineInput{
+			DescribeStateMachineWithContext(gomock.Any(), &sfn.DescribeStateMachineInput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}).
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
 		c.mockSFNAPI.EXPECT().
-			StartExecution(gomock.Any()).
+			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
 		c.mockSQSAPI.EXPECT().
 			SendMessageWithContext(gomock.Any(), gomock.Any()).
@@ -370,12 +370,12 @@ func TestRetryWorkflow(t *testing.T) {
 		workflow.Status = models.WorkflowStatusFailed
 
 		c.mockSFNAPI.EXPECT().
-			DescribeStateMachine(gomock.Any()).
+			DescribeStateMachineWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
 		c.mockSFNAPI.EXPECT().
-			StartExecution(gomock.Any()).
+			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
 		c.mockSQSAPI.EXPECT().
 			SendMessageWithContext(gomock.Any(), gomock.Any()).
@@ -413,7 +413,7 @@ func TestCancelWorkflow(t *testing.T) {
 	reason := "i have my reasons"
 	sfnExecutionARN := c.manager.executionArn(workflow, c.workflowDefinition)
 	c.mockSFNAPI.EXPECT().
-		StopExecution(&sfn.StopExecutionInput{
+		StopExecutionWithContext(gomock.Any(), &sfn.StopExecutionInput{
 			ExecutionArn: aws.String(sfnExecutionARN),
 			Cause:        aws.String(reason),
 		}).

--- a/gen-js/index.d.ts
+++ b/gen-js/index.d.ts
@@ -1,0 +1,382 @@
+import { Span, Tracer } from "opentracing";
+import { Logger } from "kayvee";
+
+type Callback<R> = (err: Error, result: R) => void;
+type ArrayInner<R> = R extends (infer T)[] ? T : never;
+
+interface RetryPolicy {
+  backoffs(): number[];
+  retry(requestOptions: {method: string}, err: Error, res: {statusCode: number}): boolean;
+}
+
+interface RequestOptions {
+  timeout?: number;
+  span?: Span;
+  retryPolicy?: RetryPolicy;
+}
+
+interface IterResult<R> {
+  map<T>(f: (r: R) => T, cb?: Callback<T[]>): Promise<T[]>;
+  toArray(cb?: Callback<R[]>): Promise<R[]>;
+  forEach(f: (r: R) => void, cb?: Callback<void>): Promise<void>;
+}
+
+interface CircuitOptions {
+  forceClosed?: boolean;
+  maxConcurrentRequests?: number;
+  requestVolumeThreshold?: number;
+  sleepWindow?: number;
+  errorPercentThreshold?: number;
+}
+
+interface GenericOptions {
+  timeout?: number;
+  keepalive?: boolean;
+  retryPolicy?: RetryPolicy;
+  logger?: Logger;
+  tracer?: Tracer;
+  circuit?: CircuitOptions;
+}
+
+interface DiscoveryOptions {
+  discovery: true;
+  address?: undefined;
+}
+
+interface AddressOptions {
+  discovery?: false;
+  address: string;
+}
+
+type WorkflowManagerOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+
+
+type CancelReason = {
+  reason?: string;
+};
+
+type CancelWorkflowParams = {
+  workflowID: string;
+  reason: CancelReason;
+};
+
+type Conflict = {
+  message?: string;
+};
+
+type DeleteStateResourceParams = {
+  namespace: string;
+  name: string;
+};
+
+type GetStateResourceParams = {
+  namespace: string;
+  name: string;
+};
+
+type GetWorkflowDefinitionByNameAndVersionParams = {
+  name: string;
+  version: number;
+};
+
+type GetWorkflowDefinitionVersionsByNameParams = {
+  name: string;
+  latest?: boolean;
+};
+
+type GetWorkflowsParams = {
+  limit?: number;
+  oldestFirst?: boolean;
+  pageToken?: string;
+  status?: string;
+  resolvedByUser?: boolean;
+  summaryOnly?: boolean;
+  workflowDefinitionName: string;
+};
+
+type Job = {
+  attempts?: JobAttempt[];
+  container?: string;
+  createdAt?: string;
+  id?: string;
+  input?: string;
+  name?: string;
+  output?: string;
+  queue?: string;
+  startedAt?: string;
+  state?: string;
+  stateResource?: StateResource;
+  status?: JobStatus;
+  statusReason?: string;
+  stoppedAt?: string;
+};
+
+type JobAttempt = {
+  containerInstanceARN?: string;
+  createdAt?: string;
+  exitCode?: number;
+  reason?: string;
+  startedAt?: string;
+  stoppedAt?: string;
+  taskARN?: string;
+};
+
+type JobStatus = ("created" | "queued" | "waiting_for_deps" | "running" | "succeeded" | "failed" | "aborted_deps_failed" | "aborted_by_user");
+
+type Manager = ("step-functions");
+
+type NewStateResource = {
+  name?: string;
+  namespace?: string;
+  uri?: string;
+};
+
+type NewWorkflowDefinitionRequest = {
+  defaultTags?: { [key: string]: {
+  
+} };
+  manager?: Manager;
+  name?: string;
+  stateMachine?: SLStateMachine;
+  version?: number;
+};
+
+type PutStateResourceParams = {
+  namespace: string;
+  name: string;
+  NewStateResource?: NewStateResource;
+};
+
+type ResolvedByUserWrapper = {
+  isSet?: boolean;
+  value?: boolean;
+};
+
+type ResumeWorkflowByIDParams = {
+  workflowID: string;
+  overrides: WorkflowDefinitionOverrides;
+};
+
+type SLCatcher = {
+  ErrorEquals?: SLErrorEquals[];
+  Next?: string;
+  ResultPath?: string;
+};
+
+type SLChoice = {
+  And?: SLChoice[];
+  BooleanEquals?: boolean;
+  Next?: string;
+  Not?: SLChoice;
+  NumericEquals?: number;
+  NumericGreaterThan?: number;
+  NumericGreaterThanEquals?: number;
+  NumericLessThan?: number;
+  NumericLessThanEquals?: number;
+  Or?: SLChoice[];
+  StringEquals?: string;
+  StringGreaterThan?: string;
+  StringGreaterThanEquals?: string;
+  StringLessThan?: string;
+  StringLessThanEquals?: string;
+  TimestampEquals?: string;
+  TimestampGreaterThan?: string;
+  TimestampGreaterThanEquals?: string;
+  TimestampLessThan?: string;
+  TimestampLessThanEquals?: string;
+  Variable?: string;
+};
+
+type SLErrorEquals = string;
+
+type SLRetrier = {
+  BackoffRate?: number;
+  ErrorEquals?: SLErrorEquals[];
+  IntervalSeconds?: number;
+  MaxAttempts?: number;
+};
+
+type SLState = {
+  Branches?: SLStateMachine[];
+  Catch?: SLCatcher[];
+  Cause?: string;
+  Choices?: SLChoice[];
+  Comment?: string;
+  Default?: string;
+  End?: boolean;
+  Error?: string;
+  HeartbeatSeconds?: number;
+  InputPath?: string;
+  Next?: string;
+  OutputPath?: string;
+  Resource?: string;
+  Result?: string;
+  ResultPath?: string;
+  Retry?: SLRetrier[];
+  Seconds?: number;
+  SecondsPath?: string;
+  TimeoutSeconds?: number;
+  Timestamp?: string;
+  TimestampPath?: string;
+  Type?: SLStateType;
+};
+
+type SLStateMachine = {
+  Comment?: string;
+  StartAt?: string;
+  States?: { [key: string]: SLState };
+  TimeoutSeconds?: number;
+  Version?: ("1.0");
+};
+
+type SLStateType = ("Pass" | "Task" | "Choice" | "Wait" | "Succeed" | "Fail" | "Parallel");
+
+type StartWorkflowRequest = {
+  input?: string;
+  namespace?: string;
+  queue?: string;
+  tags?: { [key: string]: {
+  
+} };
+  workflowDefinition?: WorkflowDefinitionRef;
+};
+
+type StateResource = {
+  lastUpdated?: string;
+  name?: string;
+  namespace?: string;
+  type?: StateResourceType;
+  uri?: string;
+};
+
+type StateResourceType = ("JobDefinitionARN" | "ActivityARN" | "LambdaFunctionARN");
+
+type UpdateWorkflowDefinitionParams = {
+  NewWorkflowDefinitionRequest?: NewWorkflowDefinitionRequest;
+  name: string;
+};
+
+type Workflow = any;
+
+type WorkflowDefinition = {
+  createdAt?: string;
+  defaultTags?: { [key: string]: {
+  
+} };
+  id?: string;
+  manager?: Manager;
+  name?: string;
+  stateMachine?: SLStateMachine;
+  version?: number;
+};
+
+type WorkflowDefinitionOverrides = {
+  StartAt?: string;
+};
+
+type WorkflowDefinitionRef = {
+  name?: string;
+  version?: number;
+};
+
+type WorkflowQuery = {
+  limit?: number;
+  oldestFirst?: boolean;
+  pageToken?: string;
+  resolvedByUserWrapper?: ResolvedByUserWrapper;
+  status?: WorkflowStatus;
+  summaryOnly?: boolean;
+  workflowDefinitionName: string;
+};
+
+type WorkflowStatus = ("queued" | "running" | "failed" | "succeeded" | "cancelled");
+
+type WorkflowSummary = {
+  createdAt?: string;
+  id?: string;
+  input?: string;
+  lastJob?: Job;
+  lastUpdated?: string;
+  namespace?: string;
+  queue?: string;
+  resolvedByUser?: boolean;
+  retries?: string[];
+  retryFor?: string;
+  status?: WorkflowStatus;
+  stoppedAt?: string;
+  tags?: { [key: string]: {
+  
+} };
+  workflowDefinition?: WorkflowDefinition;
+};
+
+declare class WorkflowManager {
+  constructor(options: WorkflowManagerOptions);
+
+  
+  healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
+  
+  postStateResource(NewStateResource?: NewStateResource, options?: RequestOptions, cb?: Callback<StateResource>): Promise<StateResource>
+  
+  deleteStateResource(params: DeleteStateResourceParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
+  
+  getStateResource(params: GetStateResourceParams, options?: RequestOptions, cb?: Callback<StateResource>): Promise<StateResource>
+  
+  putStateResource(params: PutStateResourceParams, options?: RequestOptions, cb?: Callback<StateResource>): Promise<StateResource>
+  
+  getWorkflowDefinitions(options?: RequestOptions, cb?: Callback<WorkflowDefinition[]>): Promise<WorkflowDefinition[]>
+  
+  newWorkflowDefinition(NewWorkflowDefinitionRequest?: NewWorkflowDefinitionRequest, options?: RequestOptions, cb?: Callback<WorkflowDefinition>): Promise<WorkflowDefinition>
+  
+  getWorkflowDefinitionVersionsByName(params: GetWorkflowDefinitionVersionsByNameParams, options?: RequestOptions, cb?: Callback<WorkflowDefinition[]>): Promise<WorkflowDefinition[]>
+  
+  updateWorkflowDefinition(params: UpdateWorkflowDefinitionParams, options?: RequestOptions, cb?: Callback<WorkflowDefinition>): Promise<WorkflowDefinition>
+  
+  getWorkflowDefinitionByNameAndVersion(params: GetWorkflowDefinitionByNameAndVersionParams, options?: RequestOptions, cb?: Callback<WorkflowDefinition>): Promise<WorkflowDefinition>
+  
+  getWorkflows(params: GetWorkflowsParams, options?: RequestOptions, cb?: Callback<Workflow[]>): Promise<Workflow[]>
+  getWorkflowsIter(params: GetWorkflowsParams, options?: RequestOptions): IterResult<ArrayInner<Workflow[]>>
+  
+  startWorkflow(StartWorkflowRequest?: StartWorkflowRequest, options?: RequestOptions, cb?: Callback<Workflow>): Promise<Workflow>
+  
+  CancelWorkflow(params: CancelWorkflowParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
+  
+  getWorkflowByID(workflowID: string, options?: RequestOptions, cb?: Callback<Workflow>): Promise<Workflow>
+  
+  resumeWorkflowByID(params: ResumeWorkflowByIDParams, options?: RequestOptions, cb?: Callback<Workflow>): Promise<Workflow>
+  
+  resolveWorkflowByID(workflowID: string, options?: RequestOptions, cb?: Callback<void>): Promise<void>
+  
+}
+
+declare namespace WorkflowManager {
+  const RetryPolicies: {
+    Single: RetryPolicy;
+    Exponential: RetryPolicy;
+    None: RetryPolicy;
+  }
+
+  const DefaultCircuitOptions: CircuitOptions;
+
+  namespace Errors {
+    
+    class BadRequest {
+  message?: string;
+}
+    
+    class InternalError {
+  message?: string;
+}
+    
+    class NotFound {
+  message?: string;
+}
+    
+    class Conflict {
+  message?: string;
+}
+    
+  }
+}
+
+export = WorkflowManager;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -11,5 +11,8 @@
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"
+  },
+  "devDependencies": {
+    "typescript": "^3.3.0"
   }
 }

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/handler.go
+++ b/handler.go
@@ -221,7 +221,7 @@ func (h Handler) GetWorkflows(
 		indexName = "clever-dev-workflow-manager-dev-v3-workflows"
 	}
 	req := []func(*esapi.SearchRequest){
-		h.es.Search.WithContext(context.Background()),
+		h.es.Search.WithContext(ctx),
 		h.es.Search.WithIndex(indexName),
 		h.es.Search.WithFrom(0),
 		h.es.Search.WithSourceIncludes(

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.10.1
+  version: 0.11.0
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
This branch adds tracing to workflow manager (in addition to the baseline tracing from wag). It uses the same `opentracing-contrib/aws-sdk-go` to put some coarse tracing around SFN and SQS calls, uses some handwritten spans for elasticsearch, and throws in a couple of spans around some other things for good measure. In order to make this work well, I needed to pass around a context in a few more places than already had it. 

### Remarks
* In one place, I changed an existing log call to use a different key name - from "wf-id" to "workflow-id" which is used in other places within this library and elsewhere. I don't think this breaks anything, but it would make searching for logs across a bit weird. It can still be done with `wf-id:<ID> OR workflow-id:<ID>`, though, so I think I'd rather have it cleaner going forward.

* I'm _fairly_ sure passing a context to the AWS calls doesn't affect functionality, but I'm not 100% sure. 

* Probably this shouldn't be the final home for the little elasticsearch tracing wrapper, but maybe it's okay to leave it here for now as a proof of concept? Unless you have a suggestion for somewhere better!

### PR Template Checklist:

- [x] Update swagger.yml version - no changes, so not needed!
- [x] Run "make generate"
