### PR TITLE
Tracing cleanup

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -123,15 +123,18 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 			// workflow has disappeared from our DB. No sense in
 			// trying to update it again, so delete the SQS message
 			deleteMsg()
-			return "", fmt.Errorf("worfklow id not found: %s", wfID)
+			span.SetTag("result", "workflow-not-found")
+			return "", fmt.Errorf("workflow id not found: %s", wfID)
 		}
 		// other error, e.g. throttling. Try again later
 		deleteMsg()
 		requeueMsg()
+		span.SetTag("result", "database-error")
 		return "", err
 	}
 
 	logPendingWorkflowUpdateLag(wf)
+	span.SetTag("result", "databaseError")
 
 	var storeSaveFailed = true
 	// Attempt to update the workflow, i.e. sync data from SFN into our workflow object.
@@ -139,8 +142,14 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	// and re-queue a new message if the workflow remains pending.
 	defer func() {
 		deleteMsg()
-		if storeSaveFailed || !resources.WorkflowStatusIsDone(&wf) {
+		if storeSaveFailed {
+			span.SetTag("result", "requeue-store-save-failed")
 			requeueMsg()
+		}
+		if !resources.WorkflowStatusIsDone(&wf) {
+			span.SetTag("result", "requeue-workflow-not-done")
+			requeueMsg()
+
 		}
 	}()
 	if err := wm.UpdateWorkflowSummary(ctx, &wf); err != nil {

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -134,7 +134,6 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	}
 
 	logPendingWorkflowUpdateLag(wf)
-	span.SetTag("result", "databaseError")
 
 	var storeSaveFailed = true
 	// Attempt to update the workflow, i.e. sync data from SFN into our workflow object.

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -144,8 +144,7 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 		if storeSaveFailed {
 			span.SetTag("result", "requeue-store-save-failed")
 			requeueMsg()
-		}
-		if !resources.WorkflowStatusIsDone(&wf) {
+		} else if !resources.WorkflowStatusIsDone(&wf) {
 			span.SetTag("result", "requeue-workflow-not-done")
 			requeueMsg()
 

--- a/main.go
+++ b/main.go
@@ -121,14 +121,6 @@ func main() {
 		func(handler http.Handler) http.Handler {
 			return http.TimeoutHandler(handler, timeout, "Request timed out")
 		},
-		func(handler http.Handler) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				newCtx, cancel := context.WithTimeout(r.Context(), timeout)
-				defer cancel()
-				r = r.WithContext(newCtx)
-				handler.ServeHTTP(w, r)
-			})
-		},
 	})
 
 	go executor.PollForPendingWorkflowsAndUpdateStore(context.Background(), wfmSFN, db, sqsapi, c.SQSQueueURL)


### PR DESCRIPTION
After looking at the source for `http.TimeoutHandler`, I think it does everything out custom little middleware gizmo does, so we don't need our custom one. Also, add some tagging to `updateWorkflow` with the result of the operation, so it can be filtered more easily.

- [x] Update swagger.yml version
- [x] Run "make generate"
