### PR TITLE
Infra 3428 startworkflow failures

### DIFF
--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -122,6 +122,9 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 		if _, ok := err.(models.NotFound); ok {
 			// workflow has disappeared from our DB. No sense in
 			// trying to update it again, so delete the SQS message
+			// since the update loop starts before starting execution,
+			// this could indicate an error in starting the workflow.
+			// if that happened, it is logged separately.
 			deleteMsg()
 			return "", fmt.Errorf("worfklow id not found: %s", wfID)
 		}

--- a/executor/workflow_manager.go
+++ b/executor/workflow_manager.go
@@ -129,8 +129,8 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 			return "", fmt.Errorf("worfklow id not found: %s", wfID)
 		}
 		// other error, e.g. throttling. Try again later
-		deleteMsg()
 		requeueMsg()
+		deleteMsg()
 		return "", err
 	}
 
@@ -141,10 +141,10 @@ func updatePendingWorkflow(ctx context.Context, m *sqs.Message, wm WorkflowManag
 	// Whether or not we are successful at this, we should delete the sqs message
 	// and re-queue a new message if the workflow remains pending.
 	defer func() {
-		deleteMsg()
 		if storeSaveFailed || !resources.WorkflowStatusIsDone(&wf) {
 			requeueMsg()
 		}
+		deleteMsg()
 	}()
 	if err := wm.UpdateWorkflowSummary(ctx, &wf); err != nil {
 		return "", err

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -223,11 +223,19 @@ func (wm *SFNWorkflowManager) CreateWorkflow(ctx context.Context, wd models.Work
 		mergedTags[k] = v
 	}
 
-	// save the workflow before starting execution to ensure we don't have untracked executions
-	// i.e. execution was started but we failed to save workflow
+	// start the update loop and save the workflow before starting execution to ensure we don't have
+	// untracked executions i.e. execution was started but we failed to save workflow
 	// If we fail starting the execution, we can resolve this out of band (TODO: should support cancelling)
+
 	workflow := resources.NewWorkflow(&wd, input, namespace, queue, mergedTags)
 	logger.FromContext(ctx).AddContext("workflow-id", workflow.ID)
+
+	err = createPendingWorkflow(ctx, workflow.ID, wm.sqsapi, wm.sqsQueueURL)
+	if err != nil {
+		// this error is logged in createPendingWorkflow with title "sqs-send-message"
+		return nil, err
+	}
+
 	if err := wm.store.SaveWorkflow(ctx, *workflow); err != nil {
 		return nil, err
 	}
@@ -238,19 +246,13 @@ func (wm *SFNWorkflowManager) CreateWorkflow(ctx context.Context, wd models.Work
 		// since we failed to start execution, remove Workflow from store
 		if delErr := wm.store.DeleteWorkflowByID(ctx, workflow.ID); delErr != nil {
 			log.ErrorD("create-workflow", logger.M{
-				"id":                       workflow.ID,
+				"workflow-id":              workflow.ID,
 				"workflow-definition-name": workflow.WorkflowDefinition.Name,
 				"message":                  "failed to delete stray workflow",
 				"error":                    fmt.Sprintf("SFNError: %s;StoreError: %s", err, delErr),
 			})
 		}
 
-		return nil, err
-	}
-
-	// start update loop for this workflow
-	err = createPendingWorkflow(ctx, workflow.ID, wm.sqsapi, wm.sqsQueueURL)
-	if err != nil {
 		return nil, err
 	}
 
@@ -359,6 +361,9 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(ctx context.Context, workflo
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case sfn.ErrCodeExecutionDoesNotExist:
+				// since the update loop starts before starting execution,
+				// this could mean that the workflow didn't start properly
+				// which would be logged separately
 				log.ErrorD("execution-not-found", logger.M{
 					"workflow-id":  workflow.ID,
 					"execution-id": execARN,

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -290,6 +290,10 @@ func TestCreateWorkflow(t *testing.T) {
 			c.workflowDefinition.StateMachine.StartAt,
 		)
 		awsError := awserr.New("test", "test", errors.New(""))
+
+		c.mockSQSAPI.EXPECT().
+			SendMessageWithContext(gomock.Any(), gomock.Any()).
+			Return(&sqs.SendMessageOutput{}, nil)
 		c.mockSFNAPI.EXPECT().
 			DescribeStateMachineWithContext(gomock.Any(), &sfn.DescribeStateMachineInput{
 				StateMachineArn: aws.String(stateMachineArn),

--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -302,6 +302,6 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 func AttachMiddleware(router *mux.Router, addr string, m []func(http.Handler) http.Handler) *Server {
 	l := logger.New("workflow-manager")
 
-	handler := withMiddleware("home-auth", router, m)
+	handler := withMiddleware("workflow-manager", router, m)
 	return &Server{Handler: handler, addr: addr, l: l}
 }


### PR DESCRIPTION
Jira reference: https://clever.atlassian.net/browse/INFRA-3482

This way, every workflow that was started will be picked up by an update loop, getting around the problem of a workflow not being updated because something went wrong before the SQS message was sent. See the discussion on Jira for more info.

- [x] Update swagger.yml version - not needed
- [x] Run "make generate"
