### PR TITLE
Revert "tag state machines, take two"

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -131,17 +131,6 @@ func (wm *SFNWorkflowManager) describeOrCreateStateMachine(ctx context.Context, 
 			StateMachineArn: aws.String(sfnconventions.StateMachineArn(wm.region, wm.accountID, wd.Name, wd.Version, namespace, wd.StateMachine.StartAt)),
 		})
 	if err == nil {
-		if _, err := wm.sfnapi.TagResourceWithContext(ctx, &sfn.TagResourceInput{
-			ResourceArn: describeOutput.StateMachineArn,
-			Tags: append([]*sfn.Tag{
-				{Key: aws.String("environment"), Value: aws.String(namespace)},
-				{Key: aws.String("workflow-definition-name"), Value: aws.String(wd.Name)},
-				{Key: aws.String("workflow-definition-version"), Value: aws.String(fmt.Sprintf("%d", wd.Version))},
-				{Key: aws.String("workflow-definition-start-at"), Value: aws.String(wd.StateMachine.StartAt)},
-			}, toSFNTags(wd.DefaultTags)...),
-		}); err != nil {
-			return nil, err
-		}
 		return describeOutput, nil
 	}
 	awserr, ok := err.(awserr.Error)
@@ -169,6 +158,12 @@ func (wm *SFNWorkflowManager) describeOrCreateStateMachine(ctx context.Context, 
 			Name:       aws.String(awsStateMachineName),
 			Definition: aws.String(awsStateMachineDef),
 			RoleArn:    aws.String(wm.roleARN),
+			Tags: append([]*sfn.Tag{
+				{Key: aws.String("environment"), Value: aws.String(namespace)},
+				{Key: aws.String("workflow-definition-name"), Value: aws.String(wd.Name)},
+				{Key: aws.String("workflow-definition-version"), Value: aws.String(fmt.Sprintf("%d", wd.Version))},
+				{Key: aws.String("workflow-definition-start-at"), Value: aws.String(wd.StateMachine.StartAt)},
+			}, toSFNTags(wd.DefaultTags)...),
 		})
 	if err != nil {
 		return nil, fmt.Errorf("CreateStateMachine error: %s", err.Error())

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -159,7 +159,6 @@ func TestCreateWorkflow(t *testing.T) {
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
-		c.mockSFNAPI.EXPECT().TagResourceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil)
 		c.mockSFNAPI.EXPECT().
 			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
@@ -247,7 +246,6 @@ func TestCreateWorkflow(t *testing.T) {
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
-		c.mockSFNAPI.EXPECT().TagResourceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil)
 		c.mockSFNAPI.EXPECT().
 			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
@@ -303,7 +301,6 @@ func TestCreateWorkflow(t *testing.T) {
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
-		c.mockSFNAPI.EXPECT().TagResourceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil)
 		c.mockSFNAPI.EXPECT().
 			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(nil, awsError)
@@ -344,7 +341,6 @@ func TestRetryWorkflow(t *testing.T) {
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
-		c.mockSFNAPI.EXPECT().TagResourceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil)
 		c.mockSFNAPI.EXPECT().
 			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)
@@ -382,7 +378,6 @@ func TestRetryWorkflow(t *testing.T) {
 			Return(&sfn.DescribeStateMachineOutput{
 				StateMachineArn: aws.String(stateMachineArn),
 			}, nil)
-		c.mockSFNAPI.EXPECT().TagResourceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil)
 		c.mockSFNAPI.EXPECT().
 			StartExecutionWithContext(gomock.Any(), gomock.Any()).
 			Return(&sfn.StartExecutionOutput{}, nil)


### PR DESCRIPTION
Reverts Clever/workflow-manager#217

we're going to have to backfill tagging existing state machines, we hit AWS rate limits 