### PR TITLE
Ignore es/v6/estransport when installing dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 required = ["github.com/golang/mock/mockgen"]
 
 # ignore elastic/go-elasticsearch. It uses go module suffixes, which breaks dep https://github.com/golang/dep/issues/2139
-ignored = ["github.com/elastic/go-elasticsearch", "github.com/elastic/go-elasticsearch/v6", "github.com/elastic/go-elasticsearch/v6/esapi"]
+ignored = ["github.com/elastic/go-elasticsearch", "github.com/elastic/go-elasticsearch/v6", "github.com/elastic/go-elasticsearch/v6/esapi", "github.com/elastic/go-elasticsearch/v6/estransport"]
 
 [[constraint]]
   name = "github.com/Clever/aws-sdk-go-counter"


### PR DESCRIPTION
dep does not support module suffixes (at the moment). This package was
preventing `make install_deps` from running.