### PR TITLE
Embedded allow setting execution name

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -219,12 +219,13 @@
 <a name="startworkflowrequest"></a>
 ### StartWorkflowRequest
 
-|Name|Schema|
-|---|---|
-|**input**  <br>*optional*|string|
-|**namespace**  <br>*optional*|string|
-|**queue**  <br>*optional*|string|
-|**workflowDefinition**  <br>*optional*|[WorkflowDefinitionRef](#workflowdefinitionref)|
+|Name|Description|Schema|
+|---|---|---|
+|**idSuffix**  <br>*optional*|idSuffix is exclusively used for embedded workflow-manager to append human readable information to the newly created workflow's ID. Workflow IDs are truncated to 80 characters, so some or all of the suffix may be lost|string|
+|**input**  <br>*optional*||string|
+|**namespace**  <br>*optional*||string|
+|**queue**  <br>*optional*||string|
+|**workflowDefinition**  <br>*optional*||[WorkflowDefinitionRef](#workflowdefinitionref)|
 
 
 <a name="stateresource"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.11.0
+*Version* : 0.11.1
 
 
 ### URI scheme

--- a/gen-go/models/start_workflow_request.go
+++ b/gen-go/models/start_workflow_request.go
@@ -16,6 +16,9 @@ import (
 // swagger:model StartWorkflowRequest
 type StartWorkflowRequest struct {
 
+	// idSuffix is exclusively used for embedded workflow-manager to append human readable information to the newly created workflow's ID. Workflow IDs are truncated to 80 characters, so some or all of the suffix may be lost
+	IDSuffix string `json:"idSuffix,omitempty"`
+
 	// input
 	Input string `json:"input,omitempty"`
 

--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -97,6 +97,7 @@ func (s *Server) Serve() error {
 				opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
 				opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
 				opentracing.Tag{Key: "pod_id", Value: os.Getenv("_POD_ID")},
+				opentracing.Tag{Key: "pod_shortname", Value: os.Getenv("_POD_SHORTNAME")},
 				opentracing.Tag{Key: "pod_account", Value: os.Getenv("_POD_ACCOUNT")},
 				opentracing.Tag{Key: "pod_region", Value: os.Getenv("_POD_REGION")},
 			},

--- a/gen-js/index.d.ts
+++ b/gen-js/index.d.ts
@@ -36,6 +36,7 @@ interface GenericOptions {
   logger?: Logger;
   tracer?: Tracer;
   circuit?: CircuitOptions;
+  serviceName?: string;
 }
 
 interface DiscoveryOptions {
@@ -232,6 +233,7 @@ type SLStateMachine = {
 type SLStateType = ("Pass" | "Task" | "Choice" | "Wait" | "Succeed" | "Fail" | "Parallel");
 
 type StartWorkflowRequest = {
+  idSuffix?: string;
   input?: string;
   namespace?: string;
   queue?: string;

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -168,9 +168,9 @@ class WorkflowManager {
 
     if (options.discovery) {
       try {
-        this.address = discovery("workflow-manager", "http").url();
+        this.address = discovery(options.serviceName || "workflow-manager", "http").url();
       } catch (e) {
-        this.address = discovery("workflow-manager", "default").url();
+        this.address = discovery(options.serviceName || "workflow-manager", "default").url();
       }
     } else if (options.address) {
       this.address = options.address;
@@ -193,7 +193,7 @@ class WorkflowManager {
     if (options.logger) {
       this.logger = options.logger;
     } else {
-      this.logger =  new kayvee.logger("workflow-manager-wagclient");
+      this.logger = new kayvee.logger((options.serviceName || "workflow-manager") + "-wagclient");
     }
     if (options.tracer) {
       this.tracer = options.tracer;
@@ -202,7 +202,7 @@ class WorkflowManager {
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
-    this._hystrixCommand = commandFactory.getOrCreate("workflow-manager").
+    this._hystrixCommand = commandFactory.getOrCreate(options.serviceName || "workflow-manager").
       errorHandler(this._hystrixCommandErrorHandler).
       circuitBreakerForceClosed(circuitOptions.forceClosed).
       requestVolumeRejectionThreshold(circuitOptions.maxConcurrentRequests).

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.11.0
+  version: 0.11.1
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -592,6 +592,9 @@ definitions:
         description: "tags: object with key-value pairs; keys and values should be strings"
         additionalProperties:
           type: object
+      idSuffix:
+        description: "idSuffix is exclusively used for embedded workflow-manager to append human readable information to the newly created workflow's ID. Workflow IDs are truncated to 80 characters, so some or all of the suffix may be lost"
+        type: string
 
   WorkflowDefinitionRef:
     type: object


### PR DESCRIPTION
This PR attempts to address the problem that embedded `workflow-manager` execution names do not encode human readable information. The approach we use here is to allow clients to pass in a `suffix` we append and trim to be within step functions limits

I don't think we're making any breaking changes by switching away from a UUID. That field isn't actually used in the embedded pathway at all.

My main concern is in regard to Step Functions consistency: https://docs.aws.amazon.com/step-functions/latest/dg/concepts-read-consistency.html

right now we have a 5s delay between `Update` and `StartExecution`