### PR TITLE
items is array not map

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.11.2
+*Version* : 0.11.3
 
 
 ### URI scheme

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -273,9 +273,7 @@ func (d DynamoDB) GetWorkflowDefinitions(ctx context.Context) ([]models.Workflow
 		if err != nil {
 			return []models.WorkflowDefinition{}, err
 		}
-		for k, v := range results.Items {
-			items[k] = v
-		}
+		items = append(items, results.Items...)
 		lastEvaluatedKey = results.LastEvaluatedKey
 	}
 	return d.dynamoItemsToWorkflowDefinitions(items)

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.11.2
+  version: 0.11.3
   x-npm-package: workflow-manager
 schemes:
   - http


### PR DESCRIPTION
From https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#ScanOutput
```
    // An array of item attributes that match the scan criteria. Each element in
    // this array consists of an attribute name and the value for that attribute.
    Items []map[string]*AttributeValue `type:"list"`
```

- [x] Update swagger.yml version
- [x] Run "make generate"
