### PR TITLE
Embedded WFM: allow parallel executions for a resource

### DIFF
--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -35,7 +35,7 @@ type Embedded struct {
 	sfnRoleArn          string
 	sfnAPI              sfniface.SFNAPI
 	resources           map[string]*sfnfunction.Resource
-	resourceParallelism int64
+	resourceConcurrency int64
 	workflowDefinitions []models.WorkflowDefinition
 	workerName          string
 }
@@ -45,7 +45,7 @@ var _ client.Client = &Embedded{}
 // Config for Embedded wfm.
 // Resources is a map of name to function. All functions must conform to be one of signatures defined in the following in
 //  https://github.com/Clever/workflow-manager/blob/3bd2e478da6287a2983d575f965ff010905b86ce/embedded/sfnfunction/sfnfunction.go#L24-L33
-// ResourceParallelism is how many parallel executions should be executed for each resource.
+// ResourceConcurrency is how many concurrent executions should be executed for each resource.
 //  It is a global setting for all resources that defaults to 1
 type Config struct {
 	Environment         string
@@ -55,13 +55,13 @@ type Config struct {
 	SFNRoleArn          string
 	SFNAPI              sfniface.SFNAPI
 	Resources           map[string]interface{}
-	ResourceParallelism int64
+	ResourceConcurrency int64
 	WorkflowDefinitions []byte
 	WorkerName          string
 }
 
-// DefaultResourceParallelism ...
-var DefaultResourceParallelism int64 = 1
+// DefaultResourceConcurrency ...
+var DefaultResourceConcurrency int64 = 1
 
 func (c Config) validate() error {
 	if c.Environment == "" {
@@ -133,7 +133,7 @@ func New(config *Config) (*Embedded, error) {
 		sfnRoleArn:          config.SFNRoleArn,
 		sfnAPI:              config.SFNAPI,
 		resources:           r,
-		resourceParallelism: max(config.ResourceParallelism, DefaultResourceParallelism),
+		resourceConcurrency: max(config.ResourceConcurrency, DefaultResourceConcurrency),
 		workflowDefinitions: wfdefs,
 		workerName:          wn,
 	}, nil

--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -35,7 +35,7 @@ type Embedded struct {
 	sfnRoleArn          string
 	sfnAPI              sfniface.SFNAPI
 	resources           map[string]*sfnfunction.Resource
-	resourceConcurrency int64
+	concurrencyLimits   map[string]int64
 	workflowDefinitions []models.WorkflowDefinition
 	workerName          string
 }
@@ -43,21 +43,25 @@ type Embedded struct {
 var _ client.Client = &Embedded{}
 
 // Config for Embedded wfm.
-// Resources is a map of name to function. All functions must conform to be one of signatures defined in the following in
-//  https://github.com/Clever/workflow-manager/blob/3bd2e478da6287a2983d575f965ff010905b86ce/embedded/sfnfunction/sfnfunction.go#L24-L33
-// ResourceConcurrency is how many concurrent executions should be executed for each resource.
-//  It is a global setting for all resources that defaults to 1
 type Config struct {
-	Environment         string
-	App                 string
-	SFNAccountID        string
-	SFNRegion           string
-	SFNRoleArn          string
-	SFNAPI              sfniface.SFNAPI
-	Resources           map[string]interface{}
-	ResourceConcurrency int64
-	WorkflowDefinitions []byte
-	WorkerName          string
+	Environment  string
+	App          string
+	SFNAccountID string
+	SFNRegion    string
+	SFNRoleArn   string
+	SFNAPI       sfniface.SFNAPI
+	// Resources is a map of name to function. All functions must conform to be one of signatures defined in the following in
+	// https://github.com/Clever/workflow-manager/blob/3bd2e478da6287a2983d575f965ff010905b86ce/embedded/sfnfunction/sfnfunction.go#L24-L33
+	Resources map[string]interface{}
+	// PerResourceConcurrencyLimits sets concurrency limits by resource.
+	// It takes precedence over AllResourceConcurrency
+	PerResourceConcurrencyLimits map[string]int64
+	// AllResourceConcurrencyLimit sets a concurrency limit across all resources.
+	// It is a global setting for all resources that defaults to 1.
+	// It is safe to alongside PerResourceConcurrencyLimits.
+	AllResourceConcurrencyLimit int64
+	WorkflowDefinitions         []byte
+	WorkerName                  string
 }
 
 // DefaultResourceConcurrency ...
@@ -103,12 +107,17 @@ func New(config *Config) (*Embedded, error) {
 		return nil, err
 	}
 	r := map[string]*sfnfunction.Resource{}
+	concurrencyLimits := make(map[string]int64)
 	for k := range config.Resources {
 		kcopy := k
 		var err error
 		if r[kcopy], err = sfnfunction.New(kcopy, config.Resources[kcopy]); err != nil {
 			return nil, errors.Errorf("function '%s': %s", kcopy, err.Error())
 		}
+		concurrencyLimits[kcopy] = max(config.AllResourceConcurrencyLimit, DefaultResourceConcurrency)
+	}
+	for k, v := range config.PerResourceConcurrencyLimits {
+		concurrencyLimits[k] = v
 	}
 	for _, wfdef := range wfdefs {
 		if err := validateWorkflowDefinition(wfdef, r); err != nil {
@@ -133,7 +142,7 @@ func New(config *Config) (*Embedded, error) {
 		sfnRoleArn:          config.SFNRoleArn,
 		sfnAPI:              config.SFNAPI,
 		resources:           r,
-		resourceConcurrency: max(config.ResourceConcurrency, DefaultResourceConcurrency),
+		concurrencyLimits:   concurrencyLimits,
 		workflowDefinitions: wfdefs,
 		workerName:          wn,
 	}, nil

--- a/embedded/poll.go
+++ b/embedded/poll.go
@@ -58,7 +58,7 @@ func (e *Embedded) pollGetActivityTask(ctx context.Context, resourceName string,
 			continue
 		}
 		// short circuit at the configured limit
-		if atomic.LoadInt64(concurrentExecutions) == e.concurrencyLimits[resourceName] {
+		if atomic.LoadInt64(concurrentExecutions) >= e.concurrencyLimits[resourceName] {
 			continue
 		}
 		select {

--- a/embedded/poll.go
+++ b/embedded/poll.go
@@ -41,14 +41,15 @@ func (e *Embedded) PollForWork(ctx context.Context) error {
 		}
 		log.InfoD("startup", logger.M{"activity": *createOutput.ActivityArn})
 		r := resource
+		rName := resourceName
 		g.Go(func() error {
-			return e.pollGetActivityTask(ctx, r, *createOutput.ActivityArn)
+			return e.pollGetActivityTask(ctx, rName, r, *createOutput.ActivityArn)
 		})
 	}
 	return g.Wait()
 }
 
-func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunction.Resource, activityArn string) error {
+func (e *Embedded) pollGetActivityTask(ctx context.Context, resourceName string, resource *sfnfunction.Resource, activityArn string) error {
 	concurrentExecutions := swag.Int64(0)
 	// allow one GetActivityTask per second, max 1 at a time
 	limiter := rate.NewLimiter(rate.Every(1*time.Second), 1)
@@ -57,7 +58,7 @@ func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunctio
 			continue
 		}
 		// short circuit at the configured limit
-		if atomic.LoadInt64(concurrentExecutions) == e.resourceConcurrency {
+		if atomic.LoadInt64(concurrentExecutions) == e.concurrencyLimits[resourceName] {
 			continue
 		}
 		select {
@@ -83,11 +84,7 @@ func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunctio
 			input := *out.Input
 			token := *out.TaskToken
 			log.TraceD("getactivitytask", logger.M{"input": input, "token": shortToken(token)})
-			atomic.AddInt64(concurrentExecutions, 1)
-			go func() {
-				e.handleTask(ctx, resource, token, input)
-				atomic.AddInt64(concurrentExecutions, -1)
-			}()
+			go e.concurrentlyHandleTask(ctx, concurrentExecutions, resourceName, resource, token, input)
 		}
 	}
 	return nil
@@ -99,6 +96,21 @@ func shortToken(token string) string {
 		return shasum[0:5]
 	}
 	return shasum
+}
+
+// concurrentlyHandleTask is a thin wrapper on handleTask to guarantee consistency for the internal concurency state
+func (e *Embedded) concurrentlyHandleTask(ctx context.Context, concurrentExecutions *int64, resourceName string, resource *sfnfunction.Resource, token, input string) {
+	atomic.AddInt64(concurrentExecutions, 1)
+	defer func() {
+		if r := recover(); r != nil {
+			log.WarnD("handle-task-recovered", logger.M{
+				"panic":    r,
+				"resource": resourceName,
+			})
+		}
+		atomic.AddInt64(concurrentExecutions, -1)
+	}()
+	e.handleTask(ctx, resource, token, input)
 }
 
 // handleTask sends heartbeats to SFN, invokes the resource function, and

--- a/embedded/poll.go
+++ b/embedded/poll.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Clever/workflow-manager/embedded/sfnfunction"
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
+	"github.com/go-openapi/swag"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 	errors "golang.org/x/xerrors"
@@ -47,10 +49,15 @@ func (e *Embedded) PollForWork(ctx context.Context) error {
 }
 
 func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunction.Resource, activityArn string) error {
+	concurrentExecutions := swag.Int64(0)
 	// allow one GetActivityTask per second, max 1 at a time
 	limiter := rate.NewLimiter(rate.Every(1*time.Second), 1)
 	for ctx.Err() == nil {
 		if err := limiter.Wait(ctx); err != nil {
+			continue
+		}
+		// short circuit if we're already at our configured parallelism limit
+		if atomic.LoadInt64(concurrentExecutions) == e.resourceParallelism {
 			continue
 		}
 		select {
@@ -76,7 +83,11 @@ func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunctio
 			input := *out.Input
 			token := *out.TaskToken
 			log.TraceD("getactivitytask", logger.M{"input": input, "token": shortToken(token)})
-			e.handleTask(ctx, resource, token, input)
+			atomic.AddInt64(concurrentExecutions, 1)
+			go func() {
+				e.handleTask(ctx, resource, token, input)
+				atomic.AddInt64(concurrentExecutions, -1)
+			}()
 		}
 	}
 	return nil

--- a/embedded/poll.go
+++ b/embedded/poll.go
@@ -56,8 +56,8 @@ func (e *Embedded) pollGetActivityTask(ctx context.Context, resource *sfnfunctio
 		if err := limiter.Wait(ctx); err != nil {
 			continue
 		}
-		// short circuit if we're already at our configured parallelism limit
-		if atomic.LoadInt64(concurrentExecutions) == e.resourceParallelism {
+		// short circuit at the configured limit
+		if atomic.LoadInt64(concurrentExecutions) == e.resourceConcurrency {
 			continue
 		}
 		select {


### PR DESCRIPTION
Embedded WFM is an awesome abstraction to leverage running finite state machines from one place. One limitation the current implementation has is each `Resource` can have `at max 1` execution at any given time. This limitation eventually becomes a bottleneck if there is a single embedded wfm servicing a production load.

We attempt to resolve this by adding a configurable parallelism, tracking concurrency, and invoking resource calls with goroutines.