### PR TITLE
Prevent out of range panic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* mohit.gupta@clever.com
+* @Clever/eng-infra

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -580,7 +580,11 @@ func eventToJob(
 		sfn.HistoryEventTypeExecutionFailed,
 		sfn.HistoryEventTypeExecutionTimedOut:
 		// Execution-level event - update last seen job.
-		return jobs[len(jobs)-1], eventIDToJob
+		if len(jobs) > 0 {
+			return jobs[len(jobs)-1], eventIDToJob
+		}
+		log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
+		return nil, eventIDToJob
 	default:
 		// associate this event with the same job as its parent event
 		jobOfParent, ok := eventIDToJob[parentEventID]


### PR DESCRIPTION
We're seeing [some panics](https://dev-infra--haproxy-logs.int.clever.com/_plugin/kibana/app/kibana#/discover?_a=(columns:!(rawlog),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'77a51410-ffde-11e8-8a0a-ada6ce1be4ca',key:path,negate:!t,params:(query:%2F_health),type:phrase,value:%2F_health),query:(match:(path:(query:%2F_health,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'77a51410-ffde-11e8-8a0a-ada6ce1be4ca',key:title,negate:!t,params:(query:'please%20set%20TRACING_ACCESS_TOKEN%20%26%20TRACING_INGEST_URL%20to%20enable%20tracing'),type:phrase,value:'please%20set%20TRACING_ACCESS_TOKEN%20%26%20TRACING_INGEST_URL%20to%20enable%20tracing'),query:(match:(title:(query:'please%20set%20TRACING_ACCESS_TOKEN%20%26%20TRACING_INGEST_URL%20to%20enable%20tracing',type:phrase))))),index:'77a51410-ffde-11e8-8a0a-ada6ce1be4ca',interval:auto,query:(language:lucene,query:'container_app:workflow-manager'),sort:!(!(timestamp,desc)))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2020-08-05T16:56:53.927Z',to:'2020-08-05T17:13:27.668Z'))) due to this line in dev. It is not expected but not terribly surprising either that things would get out of sync in dev between Step Functions and what workflow-manager is expecting, but besides that, this probably shouldn't panic 

- n/a: Update swagger.yml version
- n/a: Run "make generate"
