### PR TITLE
glue jobs in workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,13 @@
+## Link to JIRA:
+[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-????)
+
+## Overview:
+[insert description]
+
+If you made any changes to swagger.yml:
 - [ ] Update swagger.yml version
 - [ ] Run "make generate"
+
+## Testing
+
+## Rollout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -62,7 +62,7 @@
   version = "v9"
 
 [[projects]]
-  digest = "1:a960a527552b31abd560811cdb88fe599482513c2d30ab322532a7e725dcf564"
+  digest = "1:3d8f3662cc69607e609cbe1faecbd0f1501e37babc8f369308d6be640d6fddc3"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -84,11 +84,15 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/context",
     "internal/ini",
     "internal/sdkio",
+    "internal/sdkmath",
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
     "private/protocol",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
@@ -104,10 +108,11 @@
     "service/sqs",
     "service/sqs/sqsiface",
     "service/sts",
+    "service/sts/stsiface",
   ]
   pruneopts = ""
-  revision = "bdafd99f31a0103ec73bcabfc9498aef3252d515"
-  version = "v1.19.47"
+  revision = "e5e22aaa2543357eff98584e86fd848e0e9730a3"
+  version = "v1.34.12"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,8 +7,8 @@ ignored = [
 required = ["github.com/golang/mock/mockgen"]
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/Clever/aws-sdk-go-counter"
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.34.0"
 
 [[constraint]]
   name = "github.com/Clever/discovery-go"

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -242,7 +242,7 @@
 
 <a name="stateresourcetype"></a>
 ### StateResourceType
-*Type* : enum (JobDefinitionARN, ActivityARN, LambdaFunctionARN)
+*Type* : enum (JobDefinitionARN, ActivityARN, LambdaFunctionARN, TaskARN)
 
 
 <a name="workflow"></a>

--- a/executor/sfnconventions/sfnconventions.go
+++ b/executor/sfnconventions/sfnconventions.go
@@ -59,6 +59,11 @@ func LambdaResource(wdResource, region, accountID, namespace string) string {
 	return fmt.Sprintf("arn:aws:lambda:%s:%s:function:%s--%s", region, accountID, namespace, strings.TrimPrefix(wdResource, "lambda:"))
 }
 
+// GlueState returns the resource name and JobName parameter used for running a Glue job.
+func GlueResourceAndJobName(wdResource, namespace string) (string, string) {
+	return "arn:aws:states:::glue:startJobRun.sync", fmt.Sprintf("%s--%s", namespace, strings.TrimPrefix(wdResource, "glue:"))
+}
+
 // EmbeddedResourceArn is the activity ARN registered by embedded WFM.
 func EmbeddedResourceArn(wdResource, region, accountID, namespace string, app string) string {
 	return fmt.Sprintf("arn:aws:states:%s:%s:activity:%s--%s-%s", region, accountID, namespace, app, wdResource)

--- a/gen-go/models/s_l_state.go
+++ b/gen-go/models/s_l_state.go
@@ -54,6 +54,9 @@ type SLState struct {
 	// output path
 	OutputPath string `json:"OutputPath,omitempty"`
 
+	// parameters
+	Parameters map[string]interface{} `json:"Parameters,omitempty"`
+
 	// resource
 	Resource string `json:"Resource,omitempty"`
 

--- a/gen-go/models/state_resource_type.go
+++ b/gen-go/models/state_resource_type.go
@@ -25,6 +25,8 @@ const (
 	StateResourceTypeActivityARN StateResourceType = "ActivityARN"
 	// StateResourceTypeLambdaFunctionARN captures enum value "LambdaFunctionARN"
 	StateResourceTypeLambdaFunctionARN StateResourceType = "LambdaFunctionARN"
+	// StateResourceTypeTaskARN captures enum value "TaskARN"
+	StateResourceTypeTaskARN StateResourceType = "TaskARN"
 )
 
 // for schema
@@ -32,7 +34,7 @@ var stateResourceTypeEnum []interface{}
 
 func init() {
 	var res []StateResourceType
-	if err := json.Unmarshal([]byte(`["JobDefinitionARN","ActivityARN","LambdaFunctionARN"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["JobDefinitionARN","ActivityARN","LambdaFunctionARN","TaskARN"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/gen-js/index.d.ts
+++ b/gen-js/index.d.ts
@@ -295,6 +295,9 @@ declare namespace WorkflowManager {
   InputPath?: string;
   Next?: string;
   OutputPath?: string;
+  Parameters?: { [key: string]: {
+  
+} };
   Resource?: string;
   Result?: string;
   ResultPath?: string;
@@ -336,7 +339,7 @@ declare namespace WorkflowManager {
   uri?: string;
 };
     
-    type StateResourceType = ("JobDefinitionARN" | "ActivityARN" | "LambdaFunctionARN");
+    type StateResourceType = ("JobDefinitionARN" | "ActivityARN" | "LambdaFunctionARN" | "TaskARN");
     
     type UpdateWorkflowDefinitionParams = {
   NewWorkflowDefinitionRequest?: NewWorkflowDefinitionRequest;

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,9 +333,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -578,9 +578,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
+      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
       "optional": true
     },
     "underscore": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -641,6 +641,7 @@ definitions:
       - "JobDefinitionARN"
       - "ActivityARN"
       - "LambdaFunctionARN"
+      - "TaskARN"
 
   # States Language Types: https://states-language.net/spec.html
   SLStateMachine:
@@ -672,6 +673,9 @@ definitions:
         type: string
       End:
         type: boolean
+      Parameters:
+        additionalProperties:
+          type: object
       InputPath:
         type: string
       OutputPath:


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-4008

## Overview:
Adding support for Glue jobs in workflows. They'll look like this
```
States:
  start:
    End: true
    Parameters:
      Arguments.$: $.PATH_NAME
    Resource: glue:APP_NAME
    TimeoutSeconds: 7200
    Type: Task
```

This gets transformed into something like
```
States:
  start:
    End: true
    Parameters:
      JobName: ENVIRONMENT/NAMESPACE--APP_NAME
      Arguments.$: $.PATH_NAME
    Resource: arn:aws:states:::glue:startJobRun.sync
    TimeoutSeconds: 7200
    Type: Task
```

To pass in arguments, you can either specify them explicitly, or to pull them from the path you can do it like above with the `.$/$.` notations

If you made any changes to swagger.yml:
- [x] Update swagger.yml version
- [x] Run "make generate"

## Testing
- [Published a new workflow definition in dev](https://us-west-1.console.aws.amazon.com/dynamodb/home?region=us-west-1#tables:selected=workflow-manager-dev-v3-latest-workflow-definitions;tab=items)
- [Successful execution submitted by wfm in dev](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:clever-dev--test-glue-workflow--1--start:ee63af16-297d-4070-8f44-a9b25d59e0ca)

## Rollout
- [ ] announce to #eng and #eng-analytics and #data-engineering
- [x] add some details to https://clever.atlassian.net/wiki/spaces/ENG/pages/246579345/Workflows and https://clever.atlassian.net/wiki/spaces/ENG/pages/754745733/Glue
- [ ] add default workflow definition for glue template in init-service