### PR TITLE
Infrang 3783 support for parallel states

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -186,6 +186,9 @@
 |**Error**  <br>*optional*|string|
 |**HeartbeatSeconds**  <br>*optional*|integer|
 |**InputPath**  <br>*optional*|string|
+|**ItemsPath**  <br>*optional*|string|
+|**Iterator**  <br>*optional*|[SLStateMachine](#slstatemachine)|
+|**MaxConcurrency**  <br>*optional*|integer|
 |**Next**  <br>*optional*|string|
 |**OutputPath**  <br>*optional*|string|
 |**Resource**  <br>*optional*|string|
@@ -213,7 +216,7 @@
 
 <a name="slstatetype"></a>
 ### SLStateType
-*Type* : enum (Pass, Task, Choice, Wait, Succeed, Fail, Parallel)
+*Type* : enum (Pass, Task, Choice, Wait, Succeed, Fail, Parallel, Map)
 
 
 <a name="startworkflowrequest"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.12.0
+*Version* : 0.13.0
 
 
 ### URI scheme

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -23,7 +23,7 @@ var _ = strconv.FormatInt
 var _ = bytes.Compare
 
 // Version of the client.
-const Version = "0.12.0"
+const Version = "0.13.0"
 
 // VersionHeader is sent with every request.
 const VersionHeader = "X-Client-Version"

--- a/gen-go/models/s_l_state.go
+++ b/gen-go/models/s_l_state.go
@@ -48,6 +48,15 @@ type SLState struct {
 	// input path
 	InputPath string `json:"InputPath,omitempty"`
 
+	// items path
+	ItemsPath string `json:"ItemsPath,omitempty"`
+
+	// iterator
+	Iterator *SLStateMachine `json:"Iterator,omitempty"`
+
+	// max concurrency
+	MaxConcurrency int64 `json:"MaxConcurrency,omitempty"`
+
 	// next
 	Next string `json:"Next,omitempty"`
 
@@ -65,6 +74,9 @@ type SLState struct {
 
 	// result path
 	ResultPath string `json:"ResultPath,omitempty"`
+
+	// result selector
+	ResultSelector map[string]string `json:"ResultSelector,omitempty"`
 
 	// retry
 	Retry []*SLRetrier `json:"Retry,omitempty"`
@@ -103,6 +115,11 @@ func (m *SLState) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateChoices(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := m.validateIterator(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -199,6 +216,25 @@ func (m *SLState) validateChoices(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (m *SLState) validateIterator(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Iterator) { // not required
+		return nil
+	}
+
+	if m.Iterator != nil {
+
+		if err := m.Iterator.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("Iterator")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/gen-go/models/s_l_state_type.go
+++ b/gen-go/models/s_l_state_type.go
@@ -33,6 +33,8 @@ const (
 	SLStateTypeFail SLStateType = "Fail"
 	// SLStateTypeParallel captures enum value "Parallel"
 	SLStateTypeParallel SLStateType = "Parallel"
+	// SLStateTypeMap captures enum value "Map"
+	SLStateTypeMap SLStateType = "Map"
 )
 
 // for schema
@@ -40,7 +42,7 @@ var sLStateTypeEnum []interface{}
 
 func init() {
 	var res []SLStateType
-	if err := json.Unmarshal([]byte(`["Pass","Task","Choice","Wait","Succeed","Fail","Parallel"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Pass","Task","Choice","Wait","Succeed","Fail","Parallel","Map"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/gen-js/index.d.ts
+++ b/gen-js/index.d.ts
@@ -293,6 +293,9 @@ declare namespace WorkflowManager {
   Error?: string;
   HeartbeatSeconds?: number;
   InputPath?: string;
+  ItemsPath?: string;
+  Iterator?: SLStateMachine;
+  MaxConcurrency?: number;
   Next?: string;
   OutputPath?: string;
   Parameters?: { [key: string]: {
@@ -301,6 +304,7 @@ declare namespace WorkflowManager {
   Resource?: string;
   Result?: string;
   ResultPath?: string;
+  ResultSelector?: { [key: string]: string };
   Retry?: SLRetrier[];
   Seconds?: number;
   SecondsPath?: string;
@@ -318,7 +322,7 @@ declare namespace WorkflowManager {
   Version?: ("1.0");
 };
     
-    type SLStateType = ("Pass" | "Task" | "Choice" | "Wait" | "Succeed" | "Fail" | "Parallel");
+    type SLStateType = ("Pass" | "Task" | "Choice" | "Wait" | "Succeed" | "Fail" | "Parallel" | "Map");
     
     type StartWorkflowRequest = {
   idSuffix?: string;

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -2461,7 +2461,7 @@ module.exports.Errors = Errors;
 
 module.exports.DefaultCircuitOptions = defaultCircuitOptions;
 
-const version = "0.12.0";
+const version = "0.13.0";
 const versionHeader = "X-Client-Version";
 module.exports.Version = version;
 module.exports.VersionHeader = versionHeader;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       }
     },
     "collect-all": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-      "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
+      "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
       "requires": {
         "stream-connect": "^1.0.2",
         "stream-via": "^1.0.4"
@@ -578,9 +578,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
-      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
+      "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
       "optional": true
     },
     "underscore": {

--- a/resources/kitchensink.go
+++ b/resources/kitchensink.go
@@ -31,14 +31,59 @@ func KitchenSinkWorkflowDefinition(t *testing.T) *models.WorkflowDefinition {
 				},
 				"second-state": models.SLState{
 					Type:     models.SLStateTypeTask,
-					Next:     "end-state",
+					Next:     "parallel-state",
 					Resource: "fake-resource-2",
 					End:      false,
 					Retry:    []*models.SLRetrier{},
 				},
+				"parallel-state": models.SLState{
+					Type: models.SLStateTypeParallel,
+					Next: "map-state",
+					End:  false,
+					Branches: []*models.SLStateMachine{
+						&models.SLStateMachine{
+							StartAt: "branch1",
+							States: map[string]models.SLState{
+								"branch1": models.SLState{
+									Type:     models.SLStateTypeTask,
+									Resource: "fake-resource-3",
+									End:      true,
+									Retry:    []*models.SLRetrier{},
+								},
+							},
+						},
+						&models.SLStateMachine{
+							StartAt: "branch2",
+							States: map[string]models.SLState{
+								"branch2": models.SLState{
+									Type:     models.SLStateTypeTask,
+									Resource: "fake-resource-4",
+									End:      true,
+									Retry:    []*models.SLRetrier{},
+								},
+							},
+						},
+					},
+				},
+				"map-state": models.SLState{
+					Type: models.SLStateTypeMap,
+					Next: "end-state",
+					End:  false,
+					Iterator: &models.SLStateMachine{
+						StartAt: "mapStateStart",
+						States: map[string]models.SLState{
+							"mapStateStart": models.SLState{
+								Type:     models.SLStateTypeTask,
+								Resource: "fake-resource-5",
+								End:      true,
+								Retry:    []*models.SLRetrier{},
+							},
+						},
+					},
+				},
 				"end-state": models.SLState{
 					Type:     models.SLStateTypeTask,
-					Resource: "fake-resource-3",
+					Resource: "fake-resource-5",
 					End:      true,
 					Retry:    []*models.SLRetrier{},
 				},

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.12.0
+  version: 0.13.0
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -678,12 +678,19 @@ definitions:
           type: object
       InputPath:
         type: string
+      ItemsPath:
+        type: string
       OutputPath:
         type: string
       ResultPath:
         type: string
       Result:
         type: string
+      ResultSelector:
+        additionalProperties:
+          type: string
+      MaxConcurrency:
+        type: integer
       Retry:
         x-omitempty: true
         type: array
@@ -708,6 +715,9 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/SLStateMachine'
+      Iterator:
+        x-omitempty: true
+        $ref: '#/definitions/SLStateMachine'
       Default:
         type: string
       Error:
@@ -841,6 +851,7 @@ definitions:
       - "Succeed"
       - "Fail"
       - "Parallel"
+      - "Map"
 
   SLErrorEquals:
     type: string


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-3783

## Overview:
Allows for creation of workflow definitions with parallel states and submission of those workflows on AWS step functions.  Since parallel states work by having their own state machines on each branch this required adding some recursive calls on state machine validation and expansion of resource values to ARN's.  Verified that this functions as expected and I am able to submit a workflow with a parallel state.

If you made any changes to swagger.yml:
- [X] Update swagger.yml version
- [X] Run "make generate"

## Testing
Added test case for parsing parallel states.  Verified via manual ark submission using local workflow-manager that submitting workflows with parallel states works.

Parallel state workflow definition
<img width="566" alt="Screen Shot 2020-11-13 at 2 55 53 PM" src="https://user-images.githubusercontent.com/72103378/99128725-6f870400-25c0-11eb-9707-2182375f4b11.png">
Map state workflow definition
<img width="649" alt="Screen Shot 2020-11-13 at 2 57 40 PM" src="https://user-images.githubusercontent.com/72103378/99128794-9e04df00-25c0-11eb-85f1-6b0e7060ee1f.png">

[Successful parallel state run](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:clever-dev--sfncli-dummy-worker-INFRANG-3783-parallel--3--parallelStart:eb109017-38b5-4645-9a36-960b7182bb1f)

[Successful map state run](https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:clever-dev--sfncli-dummy-worker-INFRANG-3783-map--24--mapStart:fd82717f-01a7-4884-9d99-06967afcec22)



