### PR TITLE
error alerts should go to minor alerts channel not oncall

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -54,7 +54,7 @@ routes:
       title: ["start-unknown-workflow"]
     output:
       type: "notifications"
-      channel: "#oncall-infra"
+      channel: "#eng-infra-alerts-minor"
       icon: ":pipeline:"
       user: "workflow-manager"
       message: Attempted to start unknown workflow definition `%{name}` version `%{version}`


### PR DESCRIPTION
oncall is getting flooded so I am going to merge this PR