### PR TITLE
set to no homepod

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -53,8 +53,4 @@ alarms:
   extraParameters:
     source: ELB
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
## Link to JIRA:
pod migration

## Overview:
https://clever.grafana.net/d/application-dashboard/applications?orgId=1&var-environment=production&var-application=workflow-manager&var-pods=All&var-tgMetrics=All&var-albMetrics=All shows no traffic to homepod in prod!

If you made any changes to swagger.yml:
~~- [ ] Update swagger.yml version~~
~~- [ ] Run "make generate"~~

## Testing
N/A

## Rollout
- [x] merge deploy
- [ ] kill-homepod
- [x] announce #eng to `ark upgrade` if they see any wfm errors