### PR TITLE
bump maxattempts to 2000

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -168,7 +168,7 @@
 |**BackoffRate**  <br>*optional*||number|
 |**ErrorEquals**  <br>*optional*||< [SLErrorEquals](#slerrorequals) > array|
 |**IntervalSeconds**  <br>*optional*||integer|
-|**MaxAttempts**  <br>*optional*|**Minimum value** : `0`  <br>**Maximum value** : `10`|integer|
+|**MaxAttempts**  <br>*optional*|**Minimum value** : `0`  <br>**Maximum value** : `2000`|integer|
 
 
 <a name="slstate"></a>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,7 +7,7 @@ Orchestrator for AWS Step Functions
 
 
 ### Version information
-*Version* : 0.14.1
+*Version* : 0.14.2
 
 
 ### URI scheme

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -24,7 +24,7 @@ var _ = strconv.FormatInt
 var _ = bytes.Compare
 
 // Version of the client.
-const Version = "0.14.1"
+const Version = "0.14.2"
 
 // VersionHeader is sent with every request.
 const VersionHeader = "X-Client-Version"

--- a/gen-go/models/s_l_retrier.go
+++ b/gen-go/models/s_l_retrier.go
@@ -29,7 +29,7 @@ type SLRetrier struct {
 	IntervalSeconds int64 `json:"IntervalSeconds,omitempty"`
 
 	// max attempts
-	// Maximum: 10
+	// Maximum: 2000
 	// Minimum: 0
 	MaxAttempts *int64 `json:"MaxAttempts,omitempty"`
 }
@@ -82,7 +82,7 @@ func (m *SLRetrier) validateMaxAttempts(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.MaximumInt("MaxAttempts", "body", int64(*m.MaxAttempts), 10, false); err != nil {
+	if err := validate.MaximumInt("MaxAttempts", "body", int64(*m.MaxAttempts), 2000, false); err != nil {
 		return err
 	}
 

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -2285,7 +2285,7 @@ module.exports.Errors = Errors;
 
 module.exports.DefaultCircuitOptions = defaultCircuitOptions;
 
-const version = "0.14.1";
+const version = "0.14.2";
 const versionHeader = "X-Client-Version";
 module.exports.Version = version;
 module.exports.VersionHeader = versionHeader;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-manager",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Orchestrator for AWS Step Functions",
   "main": "index.js",
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bluebird": {
       "version": "3.5.5",
@@ -77,11 +77,11 @@
       }
     },
     "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
       "requires": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
@@ -211,9 +211,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -224,14 +224,14 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -333,9 +333,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -384,9 +384,9 @@
       }
     },
     "mkdirp2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
+      "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -578,9 +578,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-js": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
-      "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
+      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
       "optional": true
     },
     "underscore": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Orchestrator for AWS Step Functions
   # when changing the version here, make sure to
   # re-run `make generate` to generate clients and server
-  version: 0.14.1
+  version: 0.14.2
   x-npm-package: workflow-manager
 schemes:
   - http
@@ -827,7 +827,7 @@ definitions:
       MaxAttempts:
         type: integer
         minimum: 0
-        maximum: 10
+        maximum: 2000
 
   SLCatcher:
     type: object


### PR DESCRIPTION
## Link to JIRA:
oncall

## Overview:
identity has been using MaxAttempts value > 10 for a while now https://github.com/Clever/ark-config/blob/master/workflows/gcr-sync-pipeline.yml#L105-L113. It turns out this was not actually validated when wfm was on the previous version of wag.

Lets bump this number to 2000. AWS allows `99999999` but that seems like a lot to me so if folks ask we can always bump this again. https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html#error-handling-retrying-after-an-error

If you made any changes to swagger.yml:
- [x] Update swagger.yml version
- [x] Run "make generate"

## Testing

## Rollout
