### PR TITLE
Infrang 4907

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -55,6 +55,13 @@ alarms:
     threshold: 0.01
   extraParameters:
     source: ELB
+- type: InternalErrorAlarm
+  severity: critical
+  parameters:
+    threshold: 0.10
+    evaluationPeriods: 2
+  extraParameters:
+    source: Total
 pod_config:
   group: us-west-1
 telemetry:

--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -9,9 +9,6 @@ env:
 - AWS_SQS_REGION
 - AWS_SQS_URL
 - ES_URL
-- TRACING_ACCESS_TOKEN
-- TRACING_INGEST_URL
-- TRACING_USER_NAME
 resources:
   cpu: 0.25
   max_mem: 0.5
@@ -32,7 +29,7 @@ expose:
     type: http
     path: /_health
 shepherds:
-- mohit.gupta@clever.com
+- taylor.sutton@clever.com
 team: eng-infra
 databases:
 - dynamodb:us-west-1:workflow-manager-prod-v3


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-4907

## Overview:
- Adds a critical-level alarm to catch higher error volumes for longer.
- Also some small cleanup to launch config - remove unused env vars and set the shepherd to someone currently on the team. See also https://github.com/Clever/ark-config/pull/3856

If you made any changes to swagger.yml - N/A

## Testing
N/A

## Rollout
N/A