### PR TITLE
Add more CPU and Mem

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -10,8 +10,8 @@ env:
 - AWS_SQS_URL
 - ES_URL
 resources:
-  cpu: 0.25
-  max_mem: 0.5
+  cpu: 0.5
+  max_mem: 1.0
 autoscaling:
   min_count: 10
   max_count: 10


### PR DESCRIPTION
## Link to JIRA:
Related to FLARE-1317

## Overview:
We are seeing some scalability issues (high latency, workflow update loop falling behind). This is
an attempted quick-fix by adding more CPU and Mem, particularly since the update loop is mostly
parsing and encoding JSON which is pretty CPU intensive.

We could alternately try increasing the number of containers, but I'd like to go this direction
first and see how it goes since the current CPU and Mem values are quite small. Also, on the update
loop side, each container independently reads from the SQS queue with its own little backoff,
retries, sleeping, I am hesistant to just throw more containers as it without trying this first.

If you made any changes to swagger.yml

## Testing

## Rollout
