### PR TITLE
factor out some update loop logic into separate package

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Clever/workflow-manager/gen-go/models"
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
+	"github.com/Clever/workflow-manager/wfupdater"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -25,7 +26,6 @@ import (
 )
 
 const (
-	maxFailureReasonLines   = 3
 	executionEventsPerPage  = 200
 	sfncliCommandTerminated = "sfncli.CommandTerminated"
 
@@ -525,7 +525,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(ctx context.Context, workflo
 	// Populate the last job within WorkflowSummary on failures so that workflows can be
 	// more easily searched for and bucketed by failure state.
 	if workflow.Status == models.WorkflowStatusFailed {
-		if err := wm.updateWorkflowLastJob(ctx, workflow); err != nil {
+		if err := wfupdater.UpdateWorkflowLastJob(ctx, wm.sfnapi, execARN, workflow); err != nil {
 			return err
 		}
 		failedJob := ""
@@ -579,7 +579,7 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 		// 1) limit the results with `maxResults`
 		// 2) set `reverseOrder` to true to get most recent events first
 		// 3) stop paging once we get to to the smallest job ID (aka event ID) that is still pending
-		jobs = append(jobs, processEvents(historyOutput.Events, execARN, workflow, eventIDToJob)...)
+		jobs = append(jobs, wfupdater.ProcessEvents(historyOutput.Events, execARN, workflow, eventIDToJob)...)
 		return true
 	}); err != nil {
 		return err
@@ -587,316 +587,4 @@ func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflo
 	workflow.Jobs = jobs
 
 	return wm.store.UpdateWorkflow(ctx, *workflow)
-}
-
-// updateWorkflowLastJob queries AWS sfn for the latest events of the given state machine,
-// and it uses these events to populate LastJob within the WorkflowSummary.
-// This method is heavily inspired by UpdateWorkflowHistory, however updateWorkflowLastJob only
-// finds the last Job which is all that is needed to determine the state where a workflow has failed.
-// We try to use the sfn GetExecutionHistory API endpoint somewhat sparingly because
-// it has a relatively low rate limit, and it can take multiple calls per workflow
-// to retrieve the full event history for some workflows.
-func (wm *SFNWorkflowManager) updateWorkflowLastJob(ctx context.Context, workflow *models.Workflow) error {
-	wd := workflow.WorkflowSummary.WorkflowDefinition
-	execARN := sfnconventions.ExecutionArn(
-		wm.region,
-		wm.accountID,
-		sfnconventions.StateMachineName(wd.Name, wd.Version, workflow.Namespace, wd.StateMachine.StartAt),
-		workflow.ID,
-	)
-
-	historyOutput, err := wm.sfnapi.GetExecutionHistoryWithContext(ctx, &sfn.GetExecutionHistoryInput{
-		ExecutionArn: aws.String(execARN),
-		ReverseOrder: aws.Bool(true),
-	})
-	if err != nil {
-		return err
-	}
-
-	eventIDToJob := map[int64]*models.Job{}
-	// Events are processed chronologically, so the output of GetExecutionHistory is reversed when
-	// the events have been returned in reverse order.
-	jobs := processEvents(reverseHistory(historyOutput.Events), execARN, workflow, eventIDToJob)
-	if len(jobs) > 0 {
-		workflow.LastJob = jobs[len(jobs)-1]
-	} else {
-		log.ErrorD("empty-jobs", logger.M{
-			"workflow": *workflow,
-			"exec_arn": execARN,
-		})
-	}
-
-	return nil
-}
-
-// isActivityDoesntExistFailure checks if an execution failed because an activity doesn't exist.
-// This currently results in a cryptic AWS error, so the logic is probably over-broad: https://console.aws.amazon.com/support/home?region=us-west-2#/case/?displayId=4514731511&language=en
-// If SFN creates a more descriptive error event we should change this.
-func isActivityDoesntExistFailure(details *sfn.ExecutionFailedEventDetails) bool {
-	return aws.StringValue(details.Error) == "States.Runtime" &&
-		strings.Contains(aws.StringValue(details.Cause), "Internal Error")
-}
-
-// isActivityTimedOutFailure checks if an execution failed because an activity timed out,
-// based on the details of an 'execution failed' history event.
-func isActivityTimedOutFailure(details *sfn.ExecutionFailedEventDetails) bool {
-	return aws.StringValue(details.Error) == "States.Timeout"
-}
-
-func getLastFewLines(rawLines string) string {
-	lastFewLines := strings.Split(strings.TrimSpace(rawLines), "\n")
-	if len(lastFewLines) > maxFailureReasonLines {
-		lastFewLines = lastFewLines[len(lastFewLines)-maxFailureReasonLines:]
-	}
-
-	return strings.Join(lastFewLines, "\n")
-}
-
-func causeAndErrorNameFromFailureEvent(evt *sfn.HistoryEvent) (string, string) {
-	switch aws.StringValue(evt.Type) {
-	case sfn.HistoryEventTypeActivityFailed:
-		return aws.StringValue(evt.ActivityFailedEventDetails.Cause), aws.StringValue(evt.ActivityFailedEventDetails.Error)
-	case sfn.HistoryEventTypeActivityScheduleFailed:
-		return aws.StringValue(evt.ActivityScheduleFailedEventDetails.Cause), aws.StringValue(evt.ActivityScheduleFailedEventDetails.Error)
-	case sfn.HistoryEventTypeActivityTimedOut:
-		return aws.StringValue(evt.ActivityTimedOutEventDetails.Cause), aws.StringValue(evt.ActivityTimedOutEventDetails.Error)
-	case sfn.HistoryEventTypeExecutionAborted:
-		return aws.StringValue(evt.ExecutionAbortedEventDetails.Cause), aws.StringValue(evt.ExecutionAbortedEventDetails.Error)
-	case sfn.HistoryEventTypeExecutionFailed:
-		return aws.StringValue(evt.ExecutionFailedEventDetails.Cause), aws.StringValue(evt.ExecutionFailedEventDetails.Error)
-	case sfn.HistoryEventTypeExecutionTimedOut:
-		return aws.StringValue(evt.ExecutionTimedOutEventDetails.Cause), aws.StringValue(evt.ExecutionTimedOutEventDetails.Error)
-	case sfn.HistoryEventTypeLambdaFunctionFailed:
-		return aws.StringValue(evt.LambdaFunctionFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionFailedEventDetails.Error)
-	case sfn.HistoryEventTypeLambdaFunctionScheduleFailed:
-		return aws.StringValue(evt.LambdaFunctionScheduleFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionScheduleFailedEventDetails.Error)
-	case sfn.HistoryEventTypeLambdaFunctionStartFailed:
-		return aws.StringValue(evt.LambdaFunctionStartFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionStartFailedEventDetails.Error)
-	case sfn.HistoryEventTypeLambdaFunctionTimedOut:
-		return aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Cause), aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Error)
-	default:
-		return "", ""
-	}
-}
-
-// eventToJob returns a Job based on a AWS step-function events.
-func eventToJob(
-	evt *sfn.HistoryEvent,
-	execARN string, jobs []*models.Job,
-	eventIDToJob map[int64]*models.Job,
-) (*models.Job, map[int64]*models.Job) {
-	eventID := aws.Int64Value(evt.Id)
-	parentEventID := aws.Int64Value(evt.PreviousEventId)
-	switch *evt.Type {
-	// very first event for an execution, so there are no jobs yet
-	case sfn.HistoryEventTypeExecutionStarted,
-		// only create Jobs for Task, Choice and Succeed states
-		sfn.HistoryEventTypePassStateEntered, sfn.HistoryEventTypePassStateExited,
-		sfn.HistoryEventTypeParallelStateEntered, sfn.HistoryEventTypeParallelStateExited,
-		sfn.HistoryEventTypeWaitStateEntered, sfn.HistoryEventTypeWaitStateExited,
-		sfn.HistoryEventTypeFailStateEntered:
-		return nil, eventIDToJob
-	case sfn.HistoryEventTypeTaskStateEntered,
-		sfn.HistoryEventTypeChoiceStateEntered,
-		sfn.HistoryEventTypeSucceedStateEntered:
-		// a job is created when a supported state is entered
-		job := &models.Job{}
-		eventIDToJob[eventID] = job
-		return job, eventIDToJob
-	case sfn.HistoryEventTypeExecutionAborted,
-		sfn.HistoryEventTypeExecutionFailed,
-		sfn.HistoryEventTypeExecutionTimedOut:
-		// Execution-level event - update last seen job.
-		if len(jobs) > 0 {
-			return jobs[len(jobs)-1], eventIDToJob
-		}
-		log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
-		return nil, eventIDToJob
-	default:
-		// associate this event with the same job as its parent event
-		jobOfParent, ok := eventIDToJob[parentEventID]
-		if !ok {
-			// we should investigate these cases, since it means we have a gap in our interpretation of the event history
-			log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
-			return nil, eventIDToJob
-		}
-		eventIDToJob[eventID] = jobOfParent
-		return jobOfParent, eventIDToJob
-	}
-}
-
-// processEvents constructs the Jobs array from the AWS step-functions event history.
-func processEvents(
-	events []*sfn.HistoryEvent,
-	execARN string,
-	workflow *models.Workflow,
-	eventIDToJob map[int64]*models.Job,
-) []*models.Job {
-
-	jobs := []*models.Job{}
-
-	for _, evt := range events {
-		job, updatedEventToJob := eventToJob(evt, execARN, jobs, eventIDToJob)
-		eventIDToJob = updatedEventToJob
-		if isSupportedStateEnteredEvent(evt) {
-			jobs = append(jobs, job)
-		}
-
-		if job == nil {
-			continue
-		}
-		switch aws.StringValue(evt.Type) {
-		case sfn.HistoryEventTypeTaskStateEntered,
-			sfn.HistoryEventTypeChoiceStateEntered,
-			sfn.HistoryEventTypeSucceedStateEntered:
-			// event IDs start at 1 and are only unique to the execution, so this might not be ideal
-			job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
-			job.Attempts = []*models.JobAttempt{}
-			job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if *evt.Type != sfn.HistoryEventTypeTaskStateEntered {
-				// Non-task states technically start immediately, since they don't wait on resources:
-				job.StartedAt = job.CreatedAt
-			}
-			job.Status = models.JobStatusCreated
-			if details := evt.StateEnteredEventDetails; details != nil {
-				stateName := aws.StringValue(details.Name)
-				var stateResourceName string
-				var stateResourceType models.StateResourceType
-				stateDef, ok := workflow.WorkflowDefinition.StateMachine.States[stateName]
-				if ok {
-					if strings.HasPrefix(stateDef.Resource, "lambda:") {
-						stateResourceName = strings.TrimPrefix(stateDef.Resource, "lambda:")
-						stateResourceType = models.StateResourceTypeLambdaFunctionARN
-					} else if strings.HasPrefix(stateDef.Resource, "glue:") {
-						stateResourceName = strings.TrimPrefix(stateDef.Resource, "glue:")
-						stateResourceType = models.StateResourceTypeTaskARN
-					} else {
-						stateResourceName = stateDef.Resource
-						stateResourceType = models.StateResourceTypeActivityARN
-					}
-				}
-				job.Input = aws.StringValue(details.Input)
-				job.State = stateName
-
-				job.StateResource = &models.StateResource{
-					Name:        stateResourceName,
-					Type:        stateResourceType,
-					Namespace:   workflow.Namespace,
-					LastUpdated: strfmt.DateTime(aws.TimeValue(evt.Timestamp)),
-				}
-			}
-		case sfn.HistoryEventTypeTaskScheduled,
-			sfn.HistoryEventTypeActivityScheduled,
-			sfn.HistoryEventTypeLambdaFunctionScheduled:
-			if job.Status == models.JobStatusFailed {
-				// this is a retry, copy job data to attempt array, re-initialize job data
-				oldJobData := *job
-				*job = models.Job{}
-				job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
-				job.Attempts = append(oldJobData.Attempts, &models.JobAttempt{
-					Reason:    oldJobData.StatusReason,
-					CreatedAt: oldJobData.CreatedAt,
-					StartedAt: oldJobData.StartedAt,
-					StoppedAt: oldJobData.StoppedAt,
-					TaskARN:   oldJobData.Container,
-				})
-				job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-				job.Input = oldJobData.Input
-				job.State = oldJobData.State
-				job.StateResource = &models.StateResource{
-					Name:        oldJobData.StateResource.Name,
-					Type:        oldJobData.StateResource.Type,
-					Namespace:   oldJobData.StateResource.Namespace,
-					LastUpdated: strfmt.DateTime(aws.TimeValue(evt.Timestamp)),
-				}
-			}
-			job.Status = models.JobStatusQueued
-		case sfn.HistoryEventTypeTaskStarted,
-			sfn.HistoryEventTypeActivityStarted,
-			sfn.HistoryEventTypeLambdaFunctionStarted:
-			job.Status = models.JobStatusRunning
-			job.StartedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if details := evt.ActivityStartedEventDetails; details != nil {
-				job.Container = aws.StringValue(details.WorkerName)
-			}
-		case sfn.HistoryEventTypeActivityFailed,
-			sfn.HistoryEventTypeLambdaFunctionFailed,
-			sfn.HistoryEventTypeLambdaFunctionScheduleFailed,
-			sfn.HistoryEventTypeLambdaFunctionStartFailed:
-			job.Status = models.JobStatusFailed
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			cause, errorName := causeAndErrorNameFromFailureEvent(evt)
-			// TODO: need more natural place to put error name...
-			job.StatusReason = strings.TrimSpace(fmt.Sprintf(
-				"%s\n%s",
-				getLastFewLines(cause),
-				errorName,
-			))
-		case sfn.HistoryEventTypeActivityTimedOut, sfn.HistoryEventTypeLambdaFunctionTimedOut:
-			job.Status = models.JobStatusFailed
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			cause, errorName := causeAndErrorNameFromFailureEvent(evt)
-			job.StatusReason = strings.TrimSpace(fmt.Sprintf(
-				"%s\n%s\n%s",
-				resources.StatusReasonJobTimedOut,
-				errorName,
-				getLastFewLines(cause),
-			))
-		case sfn.HistoryEventTypeTaskSucceeded,
-			sfn.HistoryEventTypeActivitySucceeded,
-			sfn.HistoryEventTypeLambdaFunctionSucceeded:
-			job.Status = models.JobStatusSucceeded
-		case sfn.HistoryEventTypeExecutionAborted:
-			job.Status = models.JobStatusAbortedByUser
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if details := evt.ExecutionAbortedEventDetails; details != nil {
-				job.StatusReason = aws.StringValue(details.Cause)
-			}
-		case sfn.HistoryEventTypeExecutionFailed:
-			job.Status = models.JobStatusFailed
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if details := evt.ExecutionFailedEventDetails; details != nil {
-				if isActivityDoesntExistFailure(evt.ExecutionFailedEventDetails) {
-					job.StatusReason = "State resource does not exist"
-				} else if isActivityTimedOutFailure(evt.ExecutionFailedEventDetails) {
-					// do not update job status reason -- it should already be updated based on the ActivityTimedOut event
-				} else {
-					// set unknown errors to StatusReason
-					job.StatusReason = strings.TrimSpace(fmt.Sprintf(
-						"%s\n%s",
-						getLastFewLines(aws.StringValue(details.Cause)),
-						aws.StringValue(details.Error),
-					))
-				}
-			}
-		case sfn.HistoryEventTypeExecutionTimedOut:
-			job.Status = models.JobStatusFailed
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if details := evt.ExecutionTimedOutEventDetails; details != nil {
-				job.StatusReason = strings.TrimSpace(fmt.Sprintf(
-					"%s\n%s\n%s",
-					resources.StatusReasonWorkflowTimedOut,
-					aws.StringValue(details.Error),
-					getLastFewLines(aws.StringValue(details.Cause)),
-				))
-			} else {
-				job.StatusReason = resources.StatusReasonWorkflowTimedOut
-			}
-		case sfn.HistoryEventTypeTaskStateExited:
-			stateExited := evt.StateExitedEventDetails
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			if stateExited.Output != nil {
-				job.Output = aws.StringValue(stateExited.Output)
-			}
-		case sfn.HistoryEventTypeChoiceStateExited, sfn.HistoryEventTypeSucceedStateExited:
-			job.Status = models.JobStatusSucceeded
-			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
-			details := evt.StateExitedEventDetails
-			if details.Output != nil {
-				job.Output = aws.StringValue(details.Output)
-			}
-		}
-	}
-
-	return jobs
 }

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Clever/workflow-manager/resources"
 	"github.com/Clever/workflow-manager/store"
 	"github.com/Clever/workflow-manager/store/memory"
+	"github.com/Clever/workflow-manager/wfupdater"
 )
 
 type sfnManagerTestController struct {
@@ -686,7 +687,7 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 			ReverseOrder: aws.Bool(true),
 		}).
 		Return(&sfn.GetExecutionHistoryOutput{
-			Events: reverseHistory(events),
+			Events: wfupdater.ReverseHistory(events),
 		}, nil).
 		Times(1)
 
@@ -760,7 +761,7 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 			ReverseOrder: aws.Bool(true),
 		}).
 		Return(&sfn.GetExecutionHistoryOutput{
-			Events: reverseHistory(events),
+			Events: wfupdater.ReverseHistory(events),
 		}, nil).
 		Times(1)
 
@@ -1143,7 +1144,7 @@ func TestUpdateWorkflowStatusJobTimedOut(t *testing.T) {
 			ReverseOrder: aws.Bool(true),
 		}).
 		Return(&sfn.GetExecutionHistoryOutput{
-			Events: reverseHistory(events),
+			Events: wfupdater.ReverseHistory(events),
 		}, nil).
 		Times(1)
 
@@ -1215,7 +1216,7 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 			ReverseOrder: aws.Bool(true),
 		}).
 		Return(&sfn.GetExecutionHistoryOutput{
-			Events: reverseHistory(events),
+			Events: wfupdater.ReverseHistory(events),
 		}, nil).
 		Times(1)
 
@@ -1246,7 +1247,7 @@ func TestReverseHistory(t *testing.T) {
 		jobCreatedEvent,
 	}
 
-	assert.Equal(t, reversedEvents, reverseHistory(events))
+	assert.Equal(t, reversedEvents, wfupdater.ReverseHistory(events))
 }
 
 func newSFNManagerTestController(t *testing.T) *sfnManagerTestController {

--- a/wfupdater/lastjob.go
+++ b/wfupdater/lastjob.go
@@ -1,0 +1,43 @@
+package wfupdater
+
+import (
+	"context"
+
+	"github.com/Clever/workflow-manager/gen-go/models"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+// UpdateWorkflowLastJob queries AWS sfn for the latest events of the given state machine,
+// and it uses these events to populate LastJob within the WorkflowSummary.
+// This method is heavily inspired by UpdateWorkflowHistory, however updateWorkflowLastJob only
+// finds the last Job which is all that is needed to determine the state where a workflow has failed.
+// We try to use the sfn GetExecutionHistory API endpoint somewhat sparingly because
+// it has a relatively low rate limit, and it can take multiple calls per workflow
+// to retrieve the full event history for some workflows.
+func UpdateWorkflowLastJob(ctx context.Context, sfnapi sfniface.SFNAPI, execARN string, workflow *models.Workflow) error {
+	historyOutput, err := sfnapi.GetExecutionHistoryWithContext(ctx, &sfn.GetExecutionHistoryInput{
+		ExecutionArn: aws.String(execARN),
+		ReverseOrder: aws.Bool(true),
+	})
+	if err != nil {
+		return err
+	}
+
+	eventIDToJob := map[int64]*models.Job{}
+	// Events are processed chronologically, so the output of GetExecutionHistory is reversed when
+	// the events have been returned in reverse order.
+	jobs := ProcessEvents(ReverseHistory(historyOutput.Events), execARN, workflow, eventIDToJob)
+	if len(jobs) > 0 {
+		workflow.LastJob = jobs[len(jobs)-1]
+	} else {
+		log.ErrorD("empty-jobs", logger.M{
+			"workflow": *workflow,
+			"exec_arn": execARN,
+		})
+	}
+
+	return nil
+}

--- a/wfupdater/processevents.go
+++ b/wfupdater/processevents.go
@@ -1,0 +1,291 @@
+package wfupdater
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Clever/workflow-manager/gen-go/models"
+	"github.com/Clever/workflow-manager/resources"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/go-openapi/strfmt"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+var log = logger.New("workflow-manager")
+
+const (
+	maxFailureReasonLines = 3
+)
+
+// ProcessEvents constructs the Jobs array from the AWS step-functions event history.
+func ProcessEvents(
+	events []*sfn.HistoryEvent,
+	execARN string,
+	workflow *models.Workflow,
+	eventIDToJob map[int64]*models.Job,
+) []*models.Job {
+
+	jobs := []*models.Job{}
+
+	for _, evt := range events {
+		job, updatedEventToJob := eventToJob(evt, execARN, jobs, eventIDToJob)
+		eventIDToJob = updatedEventToJob
+		if isSupportedStateEnteredEvent(evt) {
+			jobs = append(jobs, job)
+		}
+
+		if job == nil {
+			continue
+		}
+		switch aws.StringValue(evt.Type) {
+		case sfn.HistoryEventTypeTaskStateEntered,
+			sfn.HistoryEventTypeChoiceStateEntered,
+			sfn.HistoryEventTypeSucceedStateEntered:
+			// event IDs start at 1 and are only unique to the execution, so this might not be ideal
+			job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
+			job.Attempts = []*models.JobAttempt{}
+			job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if *evt.Type != sfn.HistoryEventTypeTaskStateEntered {
+				// Non-task states technically start immediately, since they don't wait on resources:
+				job.StartedAt = job.CreatedAt
+			}
+			job.Status = models.JobStatusCreated
+			if details := evt.StateEnteredEventDetails; details != nil {
+				stateName := aws.StringValue(details.Name)
+				var stateResourceName string
+				var stateResourceType models.StateResourceType
+				stateDef, ok := workflow.WorkflowDefinition.StateMachine.States[stateName]
+				if ok {
+					if strings.HasPrefix(stateDef.Resource, "lambda:") {
+						stateResourceName = strings.TrimPrefix(stateDef.Resource, "lambda:")
+						stateResourceType = models.StateResourceTypeLambdaFunctionARN
+					} else if strings.HasPrefix(stateDef.Resource, "glue:") {
+						stateResourceName = strings.TrimPrefix(stateDef.Resource, "glue:")
+						stateResourceType = models.StateResourceTypeTaskARN
+					} else {
+						stateResourceName = stateDef.Resource
+						stateResourceType = models.StateResourceTypeActivityARN
+					}
+				}
+				job.Input = aws.StringValue(details.Input)
+				job.State = stateName
+
+				job.StateResource = &models.StateResource{
+					Name:        stateResourceName,
+					Type:        stateResourceType,
+					Namespace:   workflow.Namespace,
+					LastUpdated: strfmt.DateTime(aws.TimeValue(evt.Timestamp)),
+				}
+			}
+		case sfn.HistoryEventTypeTaskScheduled,
+			sfn.HistoryEventTypeActivityScheduled,
+			sfn.HistoryEventTypeLambdaFunctionScheduled:
+			if job.Status == models.JobStatusFailed {
+				// this is a retry, copy job data to attempt array, re-initialize job data
+				oldJobData := *job
+				*job = models.Job{}
+				job.ID = fmt.Sprintf("%d", aws.Int64Value(evt.Id))
+				job.Attempts = append(oldJobData.Attempts, &models.JobAttempt{
+					Reason:    oldJobData.StatusReason,
+					CreatedAt: oldJobData.CreatedAt,
+					StartedAt: oldJobData.StartedAt,
+					StoppedAt: oldJobData.StoppedAt,
+					TaskARN:   oldJobData.Container,
+				})
+				job.CreatedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+				job.Input = oldJobData.Input
+				job.State = oldJobData.State
+				job.StateResource = &models.StateResource{
+					Name:        oldJobData.StateResource.Name,
+					Type:        oldJobData.StateResource.Type,
+					Namespace:   oldJobData.StateResource.Namespace,
+					LastUpdated: strfmt.DateTime(aws.TimeValue(evt.Timestamp)),
+				}
+			}
+			job.Status = models.JobStatusQueued
+		case sfn.HistoryEventTypeTaskStarted,
+			sfn.HistoryEventTypeActivityStarted,
+			sfn.HistoryEventTypeLambdaFunctionStarted:
+			job.Status = models.JobStatusRunning
+			job.StartedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if details := evt.ActivityStartedEventDetails; details != nil {
+				job.Container = aws.StringValue(details.WorkerName)
+			}
+		case sfn.HistoryEventTypeActivityFailed,
+			sfn.HistoryEventTypeLambdaFunctionFailed,
+			sfn.HistoryEventTypeLambdaFunctionScheduleFailed,
+			sfn.HistoryEventTypeLambdaFunctionStartFailed:
+			job.Status = models.JobStatusFailed
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			cause, errorName := causeAndErrorNameFromFailureEvent(evt)
+			// TODO: need more natural place to put error name...
+			job.StatusReason = strings.TrimSpace(fmt.Sprintf(
+				"%s\n%s",
+				getLastFewLines(cause),
+				errorName,
+			))
+		case sfn.HistoryEventTypeActivityTimedOut, sfn.HistoryEventTypeLambdaFunctionTimedOut:
+			job.Status = models.JobStatusFailed
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			cause, errorName := causeAndErrorNameFromFailureEvent(evt)
+			job.StatusReason = strings.TrimSpace(fmt.Sprintf(
+				"%s\n%s\n%s",
+				resources.StatusReasonJobTimedOut,
+				errorName,
+				getLastFewLines(cause),
+			))
+		case sfn.HistoryEventTypeTaskSucceeded,
+			sfn.HistoryEventTypeActivitySucceeded,
+			sfn.HistoryEventTypeLambdaFunctionSucceeded:
+			job.Status = models.JobStatusSucceeded
+		case sfn.HistoryEventTypeExecutionAborted:
+			job.Status = models.JobStatusAbortedByUser
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if details := evt.ExecutionAbortedEventDetails; details != nil {
+				job.StatusReason = aws.StringValue(details.Cause)
+			}
+		case sfn.HistoryEventTypeExecutionFailed:
+			job.Status = models.JobStatusFailed
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if details := evt.ExecutionFailedEventDetails; details != nil {
+				if isActivityDoesntExistFailure(evt.ExecutionFailedEventDetails) {
+					job.StatusReason = "State resource does not exist"
+				} else if isActivityTimedOutFailure(evt.ExecutionFailedEventDetails) {
+					// do not update job status reason -- it should already be updated based on the ActivityTimedOut event
+				} else {
+					// set unknown errors to StatusReason
+					job.StatusReason = strings.TrimSpace(fmt.Sprintf(
+						"%s\n%s",
+						getLastFewLines(aws.StringValue(details.Cause)),
+						aws.StringValue(details.Error),
+					))
+				}
+			}
+		case sfn.HistoryEventTypeExecutionTimedOut:
+			job.Status = models.JobStatusFailed
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if details := evt.ExecutionTimedOutEventDetails; details != nil {
+				job.StatusReason = strings.TrimSpace(fmt.Sprintf(
+					"%s\n%s\n%s",
+					resources.StatusReasonWorkflowTimedOut,
+					aws.StringValue(details.Error),
+					getLastFewLines(aws.StringValue(details.Cause)),
+				))
+			} else {
+				job.StatusReason = resources.StatusReasonWorkflowTimedOut
+			}
+		case sfn.HistoryEventTypeTaskStateExited:
+			stateExited := evt.StateExitedEventDetails
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			if stateExited.Output != nil {
+				job.Output = aws.StringValue(stateExited.Output)
+			}
+		case sfn.HistoryEventTypeChoiceStateExited, sfn.HistoryEventTypeSucceedStateExited:
+			job.Status = models.JobStatusSucceeded
+			job.StoppedAt = strfmt.DateTime(aws.TimeValue(evt.Timestamp))
+			details := evt.StateExitedEventDetails
+			if details.Output != nil {
+				job.Output = aws.StringValue(details.Output)
+			}
+		}
+	}
+
+	return jobs
+}
+
+// isActivityDoesntExistFailure checks if an execution failed because an activity doesn't exist.
+// This currently results in a cryptic AWS error, so the logic is probably over-broad: https://console.aws.amazon.com/support/home?region=us-west-2#/case/?displayId=4514731511&language=en
+// If SFN creates a more descriptive error event we should change this.
+func isActivityDoesntExistFailure(details *sfn.ExecutionFailedEventDetails) bool {
+	return aws.StringValue(details.Error) == "States.Runtime" &&
+		strings.Contains(aws.StringValue(details.Cause), "Internal Error")
+}
+
+// isActivityTimedOutFailure checks if an execution failed because an activity timed out,
+// based on the details of an 'execution failed' history event.
+func isActivityTimedOutFailure(details *sfn.ExecutionFailedEventDetails) bool {
+	return aws.StringValue(details.Error) == "States.Timeout"
+}
+
+func getLastFewLines(rawLines string) string {
+	lastFewLines := strings.Split(strings.TrimSpace(rawLines), "\n")
+	if len(lastFewLines) > maxFailureReasonLines {
+		lastFewLines = lastFewLines[len(lastFewLines)-maxFailureReasonLines:]
+	}
+
+	return strings.Join(lastFewLines, "\n")
+}
+
+func causeAndErrorNameFromFailureEvent(evt *sfn.HistoryEvent) (string, string) {
+	switch aws.StringValue(evt.Type) {
+	case sfn.HistoryEventTypeActivityFailed:
+		return aws.StringValue(evt.ActivityFailedEventDetails.Cause), aws.StringValue(evt.ActivityFailedEventDetails.Error)
+	case sfn.HistoryEventTypeActivityScheduleFailed:
+		return aws.StringValue(evt.ActivityScheduleFailedEventDetails.Cause), aws.StringValue(evt.ActivityScheduleFailedEventDetails.Error)
+	case sfn.HistoryEventTypeActivityTimedOut:
+		return aws.StringValue(evt.ActivityTimedOutEventDetails.Cause), aws.StringValue(evt.ActivityTimedOutEventDetails.Error)
+	case sfn.HistoryEventTypeExecutionAborted:
+		return aws.StringValue(evt.ExecutionAbortedEventDetails.Cause), aws.StringValue(evt.ExecutionAbortedEventDetails.Error)
+	case sfn.HistoryEventTypeExecutionFailed:
+		return aws.StringValue(evt.ExecutionFailedEventDetails.Cause), aws.StringValue(evt.ExecutionFailedEventDetails.Error)
+	case sfn.HistoryEventTypeExecutionTimedOut:
+		return aws.StringValue(evt.ExecutionTimedOutEventDetails.Cause), aws.StringValue(evt.ExecutionTimedOutEventDetails.Error)
+	case sfn.HistoryEventTypeLambdaFunctionFailed:
+		return aws.StringValue(evt.LambdaFunctionFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionFailedEventDetails.Error)
+	case sfn.HistoryEventTypeLambdaFunctionScheduleFailed:
+		return aws.StringValue(evt.LambdaFunctionScheduleFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionScheduleFailedEventDetails.Error)
+	case sfn.HistoryEventTypeLambdaFunctionStartFailed:
+		return aws.StringValue(evt.LambdaFunctionStartFailedEventDetails.Cause), aws.StringValue(evt.LambdaFunctionStartFailedEventDetails.Error)
+	case sfn.HistoryEventTypeLambdaFunctionTimedOut:
+		return aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Cause), aws.StringValue(evt.LambdaFunctionTimedOutEventDetails.Error)
+	default:
+		return "", ""
+	}
+}
+
+// eventToJob returns a Job based on a AWS step-function events.
+func eventToJob(
+	evt *sfn.HistoryEvent,
+	execARN string, jobs []*models.Job,
+	eventIDToJob map[int64]*models.Job,
+) (*models.Job, map[int64]*models.Job) {
+	eventID := aws.Int64Value(evt.Id)
+	parentEventID := aws.Int64Value(evt.PreviousEventId)
+	switch *evt.Type {
+	// very first event for an execution, so there are no jobs yet
+	case sfn.HistoryEventTypeExecutionStarted,
+		// only create Jobs for Task, Choice and Succeed states
+		sfn.HistoryEventTypePassStateEntered, sfn.HistoryEventTypePassStateExited,
+		sfn.HistoryEventTypeParallelStateEntered, sfn.HistoryEventTypeParallelStateExited,
+		sfn.HistoryEventTypeWaitStateEntered, sfn.HistoryEventTypeWaitStateExited,
+		sfn.HistoryEventTypeFailStateEntered:
+		return nil, eventIDToJob
+	case sfn.HistoryEventTypeTaskStateEntered,
+		sfn.HistoryEventTypeChoiceStateEntered,
+		sfn.HistoryEventTypeSucceedStateEntered:
+		// a job is created when a supported state is entered
+		job := &models.Job{}
+		eventIDToJob[eventID] = job
+		return job, eventIDToJob
+	case sfn.HistoryEventTypeExecutionAborted,
+		sfn.HistoryEventTypeExecutionFailed,
+		sfn.HistoryEventTypeExecutionTimedOut:
+		// Execution-level event - update last seen job.
+		if len(jobs) > 0 {
+			return jobs[len(jobs)-1], eventIDToJob
+		}
+		log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
+		return nil, eventIDToJob
+	default:
+		// associate this event with the same job as its parent event
+		jobOfParent, ok := eventIDToJob[parentEventID]
+		if !ok {
+			// we should investigate these cases, since it means we have a gap in our interpretation of the event history
+			log.ErrorD("event-with-unknown-job", logger.M{"event-id": eventID, "execution-arn": execARN})
+			return nil, eventIDToJob
+		}
+		eventIDToJob[eventID] = jobOfParent
+		return jobOfParent, eventIDToJob
+	}
+}

--- a/wfupdater/sfn_events.go
+++ b/wfupdater/sfn_events.go
@@ -1,11 +1,12 @@
-package executor
+package wfupdater
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sfn"
 )
 
-func reverseHistory(events []*sfn.HistoryEvent) []*sfn.HistoryEvent {
+// ReverseHistory reverses the order of the events in the history.
+func ReverseHistory(events []*sfn.HistoryEvent) []*sfn.HistoryEvent {
 	numEvents := len(events)
 	reversedEvents := make([]*sfn.HistoryEvent, numEvents)
 	for i := 0; i < numEvents; i++ {


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-4473

## Overview:
The most involved section of the update loop is a section that pulls in the full execution history whenever a workflow fails and populates a "lastJob" field on the workflow object with more details about the failure. This PR factors out the core piece of that, a function named `updateWorkflowLastJob`. This will assist in using the logic elsewhere (forthcoming lambda fn).


If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
