### PR TITLE
Set scale to 16

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -13,8 +13,8 @@ resources:
   cpu: 0.5
   max_mem: 1.0
 autoscaling:
-  min_count: 10
-  max_count: 10
+  min_count: 16
+  max_count: 16
 aws:
   sqs:
     read:


### PR DESCRIPTION


## Overview:
[Discussion here](https://clever.slack.com/archives/CS02Z43PV/p1661980547419559)

Manually scaled to 16, but we want to make sure subsequent deploys also stay at 16 while longer term improvements are being worked on.

If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
