### PR TITLE
scale up kinesis stream in prod

### DIFF
--- a/launch/sfn-execution-events-stream.yml
+++ b/launch/sfn-execution-events-stream.yml
@@ -9,7 +9,7 @@ dev:
 prod:
   region: us-west-2
   retentionPeriodHours: 24
-  shardCount: 1
+  shardCount: 4
   alarms:
   # hitting 75% of read or write capacity
   - type: KinesisLimitsAlarm


### PR DESCRIPTION
starting to see the consumer fall behind as i turn on event log processing for more workflows
