### PR TITLE
resolved by user should be set for failed workflows

### DIFF
--- a/cmd/sfn-execution-events-consumer/main.go
+++ b/cmd/sfn-execution-events-consumer/main.go
@@ -208,8 +208,8 @@ func (h Handler) handleHistoryEvent(ctx context.Context, evt HistoryEvent) error
 		}
 	}
 
-	// we consider any successful or canceled workflow as "resolved"
-	if update.Status != nil && (*update.Status == models.WorkflowStatusSucceeded || *update.Status == models.WorkflowStatusCancelled) {
+	// we consider any completed workflow as "resolved"
+	if update.Status != nil && (*update.Status == models.WorkflowStatusSucceeded || *update.Status == models.WorkflowStatusCancelled || *update.Status == models.WorkflowStatusFailed) {
 		update.ResolvedByUser = aws.Bool(true)
 	}
 


### PR DESCRIPTION
## Link to JIRA:
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-4473)

## Overview:
Fixing a bug where failed workflows aren't showing up in hubble, which searches for resolvedByUser: true.

I'm actually not sure how it used to get set to true for failed workflows. The code changed in this PR diverges from the analogous code in the update loop: https://github.com/Clever/workflow-manager/blob/4cdb21d053b3f2a2035256214bb76c36bfea84d9/executor/workflow_manager_sfn.go#L576-L578

If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
