### PR TITLE
don't allow updating from terminal to non-terminal state

### DIFF
--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -258,6 +258,9 @@ func (s *MemoryStore) UpdateWorkflowAttributes(ctx context.Context, id string, u
 		wf.LastUpdated = *update.LastUpdated
 	}
 	if update.Status != nil {
+		if store.TerminalState(wf.Status) && !store.TerminalState(*update.Status) {
+			return store.ErrUpdatingWorkflowFromTerminalToNonTerminalState
+		}
 		wf.Status = *update.Status
 	}
 	if update.StatusReason != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -86,6 +87,26 @@ func (u UpdateWorkflowAttributesInput) ZeroValue() bool {
 		return false
 	}
 	return true
+}
+
+// ErrUpdatingWorkflowFromTerminalToNonTerminalState is returned when a workflow is updated from a terminal state to a non-terminal state.
+var ErrUpdatingWorkflowFromTerminalToNonTerminalState = errors.New("cannot update workflow from terminal to non-terminal state")
+
+// TerminalStates is a list of terminal states.
+var TerminalStates = []models.WorkflowStatus{
+	models.WorkflowStatusSucceeded,
+	models.WorkflowStatusFailed,
+	models.WorkflowStatusCancelled,
+}
+
+// TerminalState returns true if a workflow state is terminal
+func TerminalState(state models.WorkflowStatus) bool {
+	for _, s := range TerminalStates {
+		if state == s {
+			return true
+		}
+	}
+	return false
 }
 
 type ConflictError struct {

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -347,5 +347,12 @@ func UpdateWorkflowAttributes(s store.Store, t *testing.T) func(t *testing.T) {
 		assert.Equal(t, time.Time(updatedWorkflow.StoppedAt).Format(time.RFC3339Nano), time.Time(*update.StoppedAt).Format(time.RFC3339Nano))
 		assert.Equal(t, updatedWorkflow.ResolvedByUser, *update.ResolvedByUser)
 		assert.Equal(t, updatedWorkflow.Output, *update.Output)
+
+		// don't allow updating from terminal to non-terminal state
+		update = store.UpdateWorkflowAttributesInput{
+			LastUpdated: &now,
+			Status:      ptrStatus(models.WorkflowStatusRunning),
+		}
+		assert.Equal(t, store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, s.UpdateWorkflowAttributes(ctx, workflow.ID, update))
 	}
 }


### PR DESCRIPTION
## Link to JIRA:
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-4473)

## Overview:

The AWS support ticket I filed is the best overview:

> Hi,
> We have recently begun using state machine logs to process execution events. We are seeing execution logs getting split across two different log streams, which causes us to process events out of order when these logs are sent to a kinesis log subscription.
> State machine: https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/statemachines/view/arn:aws:states:us-west-2:589690932525:stateMachine:production--analytics-p11n-exports-master--1--start
> Example execution: https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/executions/details/arn:aws:states:us-west-2:589690932525:execution:production--analytics-p11n-exports-master--1--start:84e9ee97-fa45-4f32-b3ae-80a182cda7fb
> Logs for this execution got delivered to two different log streams:
> - https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Faws$252Fvendedlogs$252Fstates$252Fproduction--analytics-p11n-exports-master--1--start/log-events/states$252Fproduction--analytics-p11n-exports-master--1--start$252F2022-09-17-00$252Fe42cb9d5
> - https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Faws$252Fvendedlogs$252Fstates$252Fproduction--analytics-p11n-exports-master--1--start/log-events/states$252Fproduction--analytics-p11n-exports-master--1--start$252F2022-09-17-00$252F5ea122a4
> The log group for these log streams is subscribed to a kinesis stream using distribution by log stream, so the fact that execution events get sent to two different log streams means that the kinesis consumer processing these events might see them out of order.
> Is there a way to process these events in order? Why did the execution logs get split across log streams?
> Thanks,
> Rafael



If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
