### PR TITLE
Revert "resolved by user should be set for failed workflows"

### DIFF
--- a/cmd/sfn-execution-events-consumer/main.go
+++ b/cmd/sfn-execution-events-consumer/main.go
@@ -208,8 +208,8 @@ func (h Handler) handleHistoryEvent(ctx context.Context, evt HistoryEvent) error
 		}
 	}
 
-	// we consider any completed workflow as "resolved"
-	if update.Status != nil && (*update.Status == models.WorkflowStatusSucceeded || *update.Status == models.WorkflowStatusCancelled || *update.Status == models.WorkflowStatusFailed) {
+	// we consider any successful or canceled workflow as "resolved"
+	if update.Status != nil && (*update.Status == models.WorkflowStatusSucceeded || *update.Status == models.WorkflowStatusCancelled) {
 		update.ResolvedByUser = aws.Bool(true)
 	}
 


### PR DESCRIPTION
Reverts Clever/workflow-manager#325

The actual problem was event ordering and was solved by https://github.com/Clever/workflow-manager/pull/327