### PR TITLE
Add better context to error messages relating to terminal states

### DIFF
--- a/cmd/sfn-execution-events-consumer/main.go
+++ b/cmd/sfn-execution-events-consumer/main.go
@@ -105,11 +105,6 @@ func (h Handler) handleRecord(ctx context.Context, rec events.KinesisEventRecord
 	logger.FromContext(ctx).AddContext("log-group", d.LogGroup)
 	logger.FromContext(ctx).AddContext("log-stream", d.LogStream)
 	logger.FromContext(ctx).AddContext("kinesis-seq", rec.Kinesis.SequenceNumber)
-	defer func() {
-		logger.FromContext(ctx).AddContext("log-group", "")
-		logger.FromContext(ctx).AddContext("log-stream", "")
-		logger.FromContext(ctx).AddContext("kinesis-seq", "")
-	}()
 	logger.FromContext(ctx).InfoD("received", logger.M{"count": len(d.LogEvents)})
 	for _, evt := range d.LogEvents {
 		var historyEvent HistoryEvent
@@ -181,12 +176,8 @@ func ptrStatus(s models.WorkflowStatus) *models.WorkflowStatus {
 func (h Handler) handleHistoryEvent(ctx context.Context, evt HistoryEvent) error {
 	execID := execIDFromExecutionARN(evt.ExecutionARN)
 	smName := stateMachineFromExecutionARN(evt.ExecutionARN)
-	logger.FromContext(ctx).AddContext("id", execID)
-	logger.FromContext(ctx).AddContext("sm", smName)
-	defer func() {
-		logger.FromContext(ctx).AddContext("id", "")
-		logger.FromContext(ctx).AddContext("sm", "")
-	}()
+	logger.FromContext(ctx).AddContext("execution-id", execID)
+	logger.FromContext(ctx).AddContext("state-machine-name", smName)
 	var update store.UpdateWorkflowAttributesInput
 	if evt.ID == "2" {
 		update.Status = ptrStatus(models.WorkflowStatusRunning)

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Clever/workflow-manager/gen-go/models"
-	"github.com/Clever/workflow-manager/gen-go/server/db"
-	"github.com/Clever/workflow-manager/resources"
-	"github.com/Clever/workflow-manager/store"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -18,6 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/Clever/workflow-manager/gen-go/models"
+	"github.com/Clever/workflow-manager/gen-go/server/db"
+	"github.com/Clever/workflow-manager/resources"
+	"github.com/Clever/workflow-manager/store"
 
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
@@ -290,7 +291,7 @@ func (d DynamoDB) GetWorkflowDefinitionVersions(ctx context.Context, name string
 			"#N": aws.String("name"),
 		},
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
-			":name": &dynamodb.AttributeValue{
+			":name": {
 				S: aws.String(name),
 			},
 		},
@@ -345,7 +346,7 @@ func (d DynamoDB) LatestWorkflowDefinition(ctx context.Context, name string) (mo
 			"#N": aws.String("name"),
 		},
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
-			":name": &dynamodb.AttributeValue{
+			":name": {
 				S: aws.String(name),
 			},
 		},
@@ -516,7 +517,7 @@ func (d DynamoDB) DeleteWorkflowByID(ctx context.Context, workflowID string) err
 	_, err := d.ddb.DeleteItemWithContext(ctx, &dynamodb.DeleteItemInput{
 		TableName: aws.String(d.workflowsTable()),
 		Key: map[string]*dynamodb.AttributeValue{
-			"id": &dynamodb.AttributeValue{
+			"id": {
 				S: aws.String(workflowID),
 			},
 		},
@@ -636,7 +637,7 @@ func (d DynamoDB) UpdateWorkflowAttributes(ctx context.Context, workflowID strin
 		UpdateExpression:          expr.Update(),
 	}); err != nil {
 		if strings.Contains(err.Error(), "conditional request failed") {
-			return store.ErrUpdatingWorkflowFromTerminalToNonTerminalState
+			return fmt.Errorf("%w: attempted to update workflow to state %s: %s", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, *update.Status, err)
 		} else {
 			return err
 		}

--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -637,7 +637,7 @@ func (d DynamoDB) UpdateWorkflowAttributes(ctx context.Context, workflowID strin
 		UpdateExpression:          expr.Update(),
 	}); err != nil {
 		if strings.Contains(err.Error(), "conditional request failed") {
-			return fmt.Errorf("%w: attempted to update workflow to state %s: %s", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, *update.Status, err)
+			return fmt.Errorf("%w: attempted to update workflow to state %q: %s", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, *update.Status, err)
 		} else {
 			return err
 		}

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -258,7 +258,7 @@ func (s *MemoryStore) UpdateWorkflowAttributes(ctx context.Context, id string, u
 	}
 	if update.Status != nil {
 		if store.TerminalState(wf.Status) && !store.TerminalState(*update.Status) {
-			return fmt.Errorf("%w: %s => %s transition attempted", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, wf.Status, *update.Status)
+			return fmt.Errorf("%w: %q => %q transition attempted", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, wf.Status, *update.Status)
 		}
 		wf.Status = *update.Status
 	}

--- a/store/memory/memory_store.go
+++ b/store/memory/memory_store.go
@@ -40,7 +40,6 @@ func New() MemoryStore {
 }
 
 func (s MemoryStore) SaveWorkflowDefinition(ctx context.Context, def models.WorkflowDefinition) error {
-
 	if _, ok := s.workflowDefinitions[def.Name]; ok {
 		return store.NewConflict(def.Name)
 	}
@@ -259,7 +258,7 @@ func (s *MemoryStore) UpdateWorkflowAttributes(ctx context.Context, id string, u
 	}
 	if update.Status != nil {
 		if store.TerminalState(wf.Status) && !store.TerminalState(*update.Status) {
-			return store.ErrUpdatingWorkflowFromTerminalToNonTerminalState
+			return fmt.Errorf("%w: %s => %s transition attempted", store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, wf.Status, *update.Status)
 		}
 		wf.Status = *update.Status
 	}

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -354,6 +355,6 @@ func UpdateWorkflowAttributes(s store.Store, t *testing.T) func(t *testing.T) {
 			LastUpdated: &now,
 			Status:      ptrStatus(models.WorkflowStatusRunning),
 		}
-		assert.Equal(t, "cannot update workflow from terminal to non-terminal state: succeeded => running transition attempted", s.UpdateWorkflowAttributes(ctx, workflow.ID, update).Error())
+		assert.True(t, errors.Is(s.UpdateWorkflowAttributes(ctx, workflow.ID, update), store.ErrUpdatingWorkflowFromTerminalToNonTerminalState))
 	}
 }

--- a/store/tests/tests.go
+++ b/store/tests/tests.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Clever/workflow-manager/gen-go/models"
-	"github.com/Clever/workflow-manager/resources"
-	"github.com/Clever/workflow-manager/store"
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Clever/workflow-manager/gen-go/models"
+	"github.com/Clever/workflow-manager/resources"
+	"github.com/Clever/workflow-manager/store"
 )
 
 func RunStoreTests(t *testing.T, storeFactory func() store.Store) {
@@ -246,7 +247,7 @@ func UpdateLargeWorkflow(s store.Store, t *testing.T) func(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, savedWorkflow.Status, updatedWorkflow.Status)
 		// Large Workflows don't save Jobs in DynamoDB
-		//require.Equal(t, len(savedWorkflow.Jobs), len(updatedWorkflow.Jobs))
+		// require.Equal(t, len(savedWorkflow.Jobs), len(updatedWorkflow.Jobs))
 	}
 }
 
@@ -353,6 +354,6 @@ func UpdateWorkflowAttributes(s store.Store, t *testing.T) func(t *testing.T) {
 			LastUpdated: &now,
 			Status:      ptrStatus(models.WorkflowStatusRunning),
 		}
-		assert.Equal(t, store.ErrUpdatingWorkflowFromTerminalToNonTerminalState, s.UpdateWorkflowAttributes(ctx, workflow.ID, update))
+		assert.Equal(t, "cannot update workflow from terminal to non-terminal state: succeeded => running transition attempted", s.UpdateWorkflowAttributes(ctx, workflow.ID, update).Error())
 	}
 }


### PR DESCRIPTION
## Overview:
There are a bunch of errors causing workflows not to be updated and they are all related to this error. This PR adds additional context so the problem can be debugged more easily.