### PR TITLE
Reduce alarm noise

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -32,17 +32,11 @@ alarms:
 - type: InternalErrorAlarm
   severity: minor
   parameters:
-    threshold: 0.01
-  extraParameters:
-    source: Target
-- type: InternalErrorAlarm
-  severity: major
-  parameters:
     threshold: 0.05
   extraParameters:
     source: Target
 - type: InternalErrorAlarm
-  severity: major
+  severity: minor
   parameters:
     threshold: 0.01
   extraParameters:


### PR DESCRIPTION
## Overview
These alarms make a lot of noise in the major alerts channel and are more or less completely ignored. Major channel should only be actionable alarms. I've eliminated the previous minor alarm and routed the previous major alarm to the minor channel.
