### PR TITLE
log when zombie execution is found

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -513,6 +513,10 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(ctx context.Context, workflo
 
 				// only fail after 5 minutes to see if this is an eventual-consistency thing
 				if time.Time(workflow.LastUpdated).Before(time.Now().Add(-durationToRetryDescribeExecutions)) {
+					log.ErrorD("zombie-execution-found", logger.M{
+						"workflow-id":  workflow.ID,
+						"execution-id": execARN,
+					})
 					workflow.LastUpdated = strfmt.DateTime(time.Now())
 					workflow.Status = models.WorkflowStatusFailed
 					return wm.store.UpdateWorkflow(ctx, *workflow)

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -36,3 +36,13 @@ routes:
       icon: ":pipeline:"
       user: "workflow-manager"
       message: Attempted to start unknown workflow definition `%{name}` version `%{version}`
+
+  zombie-execution-found:
+    matchers:
+      title: ["zombie-execution-found"]
+    output:
+      type: "notifications"
+      channel: "#eng-infra-alerts-major"
+      icon: ":pipeline:"
+      user: "workflow-manager"
+      message: Found zombie execution `%{execution-id}` for workflow `%{workflow-id}`. Check ticket https://clever.atlassian.net/browse/INFRANG-4733 for details


### PR DESCRIPTION
## Link to JIRA:
[INFRANG-4733](https://clever.atlassian.net/browse/INFRANG-4733)

## Overview:
Zombie executions are defined as workflows that exist in DDB but don't have a step function execution. This can happen if workflow was added to DDB but starting execution failed and the workflow was never removed from ddb. I looked over the code and I don't see any spot where we do this. I also investigated our logs and I didn't see any evidence of zombie workflows so we must have fixed the underlying issue already. Lets add this log line to track zombie executions and get alerted on it.

In hubble we are filtering out real workflows thinking they are zombies based on https://github.com/Clever/hubble/pull/96/files. Instead of a query like this it is better to just eliminate zombie workflows which is why this log is added. In the mean time lets revert the hubble PR so that real workflows are not filtered out.

If you made any changes to swagger.yml:
- [na] Update swagger.yml version
- [na] Run "make generate"

## Testing

## Rollout
