### PR TITLE
quick fix attempt

### DIFF
--- a/wfupdater/processevents.go
+++ b/wfupdater/processevents.go
@@ -140,6 +140,7 @@ func ProcessEvents(
 			))
 		case sfn.HistoryEventTypeTaskSucceeded,
 			sfn.HistoryEventTypeActivitySucceeded,
+			"ExecutionSucceeded", // TODO: remove this and replace with a sfn.xxx once aws-sdk-go supports this event type
 			sfn.HistoryEventTypeLambdaFunctionSucceeded:
 			job.Status = models.JobStatusSucceeded
 		case sfn.HistoryEventTypeExecutionAborted:


### PR DESCRIPTION
## Link to JIRA:
https://clever.slack.com/archives/C08G6CNMN/p1691612349440029?thread_ts=1691610684.323949&cid=C08G6CNMN
https://clever.slack.com/archives/C05LPSFF1D1/p1691608755911419

## Overview:
Many workflows are not being correctly updated in hubble after succeeding. Multiverse currently has ~38k workflows marked as running, from what I can tell most of them aren't. Each of these workflows seems to match up to a DD log of "unhandled-sfn-event":"ExecutionSucceeded".

In sfn-execution-events-consumer [we handle this event by marking the job status as succeeded. ](https://github.com/Clever/workflow-manager/blob/b9c79d0e5b94f5d3c5c65366fd2b07faabb12be8/cmd/sfn-execution-events-consumer/main.go#L226-L233)

We don't do that [here](https://github.com/Clever/workflow-manager/blob/b9c79d0e5b94f5d3c5c65366fd2b07faabb12be8/wfupdater/processevents.go#L141-L144) and thus it is caught by [this](https://github.com/Clever/workflow-manager/blob/b9c79d0e5b94f5d3c5c65366fd2b07faabb12be8/wfupdater/processevents.go#L194-L201). 

The idea here is that this change would just be a partial attempt to match the processEvents function logic to the lambda logic. 

My theory is that we are seeing a lot more of these errors now because we are manually calling GetWorkflowByID() to force update these workflows, so they aren't hitting the lambda that uses the better logic. 


If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
