### PR TITLE
Revert "Enable aws sdk debug logging"

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,6 @@ func main() {
 			Region:     aws.String(c.DynamoRegion),
 			MaxRetries: &dynamoMaxRetries,
 			HTTPClient: &http.Client{Transport: dynamoTransport},
-			LogLevel:   aws.LogLevel(aws.LogDebugWithRequestErrors),
 		},
 	})))
 	db := dynamodbstore.New(svc, dynamodbstore.TableConfig{


### PR DESCRIPTION
Reverts Clever/workflow-manager#354

This logging wasn't useful and was rolled back. Lets revert it so new merges don't re-enable this. 