### PR TITLE
Oncall fix 500 spam get workflow

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -567,13 +567,6 @@ func (wm *SFNWorkflowManager) UpdateWorkflowSummary(ctx context.Context, workflo
 }
 
 func (wm *SFNWorkflowManager) UpdateWorkflowHistory(ctx context.Context, workflow *models.Workflow) error {
-	// Avoid the extraneous processing for executions that have already stopped.
-	// This also prevents the WM "cancelled" state from getting overwritten for workflows cancelled
-	// by the user after a failure.
-	if resources.WorkflowIsDone(workflow) {
-		return nil
-	}
-
 	// Pull in execution history to populate jobs array
 	// Each Job corresponds to a type={Task,Choice,Succeed} state, i.e. States we have currently tested and supported completely
 	// We only create a Job object if the State has been entered.

--- a/executor/workflow_manager_sfn_test.go
+++ b/executor/workflow_manager_sfn_test.go
@@ -576,8 +576,8 @@ func TestUpdateWorkflowStatusJobCreated(t *testing.T) {
 			cb(&sfn.GetExecutionHistoryOutput{Events: []*sfn.HistoryEvent{jobCreatedEvent}}, true)
 		})
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusRunning, workflow.Status)
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
@@ -643,8 +643,8 @@ func TestUpdateWorkflowStatusJobFailed(t *testing.T) {
 		}, nil).
 		Times(1)
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
@@ -718,8 +718,8 @@ func TestUpdateWorkflowStatusJobFailedNotDeployed(t *testing.T) {
 		}, nil).
 		Times(1)
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
 	require.Len(t, workflow.Jobs, 1)
 	assert.Equal(t, models.JobStatusFailed, workflow.Jobs[0].Status)
@@ -800,8 +800,8 @@ func TestUpdateWorkflowStatusWorkflowJobSucceeded(t *testing.T) {
 			}}, true)
 		})
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusSucceeded, workflow.Status)
 	assert.Equal(t, executionOutput, workflow.Output)
 	require.Len(t, workflow.Jobs, 1)
@@ -863,8 +863,8 @@ func TestUpdateWorkflowStatusJobCancelled(t *testing.T) {
 			}}, true)
 		})
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusCancelled, workflow.Status)
 	assert.Equal(t, "cancelled by user", workflow.StatusReason)
 	require.Len(t, workflow.Jobs, 1)
@@ -910,8 +910,8 @@ func TestUpdateWorkflowStatusWorkflowCancelledAfterJobSucceeded(t *testing.T) {
 			}}, true)
 		})
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusCancelled, workflow.Status)
 	assert.Equal(t, "cancelled by user", workflow.StatusReason)
 	require.Len(t, workflow.Jobs, 1)
@@ -969,9 +969,9 @@ func TestUpdateWorkflowStatusExecutionNotFoundRetry(t *testing.T) {
 	assert.Equal(t, models.WorkflowStatusQueued, workflow.Status)
 	require.Len(t, workflow.Jobs, 0)
 
+	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusSucceeded, workflow.Status)
-	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
 	assertSucceededJobData(t, workflow.Jobs[0])
@@ -1106,8 +1106,8 @@ func TestUpdateWorkflowStatusJobTimedOut(t *testing.T) {
 		}, nil).
 		Times(1)
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])
@@ -1179,8 +1179,8 @@ func TestUpdateWorkflowStatusWorkflowTimedOut(t *testing.T) {
 		}, nil).
 		Times(1)
 
-	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	require.NoError(t, c.manager.UpdateWorkflowHistory(ctx, workflow))
+	require.NoError(t, c.manager.UpdateWorkflowSummary(ctx, workflow))
 	assert.Equal(t, models.WorkflowStatusFailed, workflow.Status)
 	require.Len(t, workflow.Jobs, 1)
 	assertBasicJobData(t, workflow.Jobs[0])

--- a/handler.go
+++ b/handler.go
@@ -431,7 +431,6 @@ func (h Handler) GetWorkflowByID(ctx context.Context, workflowID string) (*model
 		return &models.Workflow{}, err
 	}
 
-	// update history before summary so that we can preemptively exit processing once workflow is in final state
 	if err := h.manager.UpdateWorkflowHistory(ctx, &workflow); err != nil {
 		return &models.Workflow{}, err
 	}

--- a/handler.go
+++ b/handler.go
@@ -431,11 +431,12 @@ func (h Handler) GetWorkflowByID(ctx context.Context, workflowID string) (*model
 		return &models.Workflow{}, err
 	}
 
-	if err := h.manager.UpdateWorkflowSummary(ctx, &workflow); err != nil {
+	// update history before summary so that we can preemptively exit processing once workflow is in final state
+	if err := h.manager.UpdateWorkflowHistory(ctx, &workflow); err != nil {
 		return &models.Workflow{}, err
 	}
 
-	if err := h.manager.UpdateWorkflowHistory(ctx, &workflow); err != nil {
+	if err := h.manager.UpdateWorkflowSummary(ctx, &workflow); err != nil {
 		return &models.Workflow{}, err
 	}
 


### PR DESCRIPTION
## Link to JIRA:
oncall

## Overview:
https://app.datadoghq.com/logs?query=service%3Aworkflow-manager%20env%3Aproduction%20status%3Aerror%20%40status-code%3A500%20&agg_q=%40path&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=desc&viz=query_table&from_ts=1691877731318&to_ts=1692050531318&live=true

we are seeing a spam of 500s in workflow-manager

Recently we updated hubble to remove a query which was filtering out zombie workflows https://clever.atlassian.net/browse/INFRANG-4733. Looks like now we have some zombie workflows (I haven't investigated why yet) which are now getting queried by hubble leading to this increase in 500s. We should fix the issue that caused these zombie workflows so that the they get deleted from dynamodb but in the meantime this error shouldn't be treated as a 500. Instead it should just be ignored so that `getWorkflowbyId` returns the workflow stored in dynamodb which shows that it failed.

If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing

## Rollout
