### PR TITLE
clean up alarms

### DIFF
--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -30,30 +30,18 @@ databases:
 - dynamodb:us-west-1:workflow-manager-prod-v3
 alarms:
 - type: InternalErrorAlarm
-  severity: minor
-  parameters:
-    threshold: 0.01
-  extraParameters:
-    source: Target
-- type: InternalErrorAlarm
   severity: major
   parameters:
     threshold: 0.05
-  extraParameters:
-    source: Target
 - type: InternalErrorAlarm
   severity: major
   parameters:
     threshold: 0.01
-  extraParameters:
-    source: ELB
 - type: InternalErrorAlarm
   severity: critical
   parameters:
     threshold: 0.10
     evaluationPeriods: 2
-  extraParameters:
-    source: Total
 pod_config:
   group: us-west-1
 telemetry:

--- a/launch/workflow-manager.yml
+++ b/launch/workflow-manager.yml
@@ -34,7 +34,7 @@ alarms:
   parameters:
     threshold: 0.05
 - type: InternalErrorAlarm
-  severity: major
+  severity: minor
   parameters:
     threshold: 0.01
 - type: InternalErrorAlarm


### PR DESCRIPTION
# Clean up alarms for mesh services

## JIRA

https://clever.atlassian.net/browse/INFRANG-5475

## Overview

In Mesh there is no concept of alarm source of Target, ELB and Total as all metrics are coming from envoy sidecar. We are soon going to merge a change which will block CI for applications if source field is present for InternalErrorAlarms and mesh_config for prod set to mesh_only.

You have to review this PR to see that the new alarms make sense. It was hard to script all the different alarm setups we have across services. In most cases I have removed duplicate alarms but you might want to remove some more alarms or keep some deleted alarms.

## Rollout

Merge PR and deploy via dapple.
