### PR TITLE
Don't retry saving the workflow again if we have already set the jobs to nil

### DIFF
--- a/store/dynamodb/dynamodb_store.go
+++ b/store/dynamodb/dynamodb_store.go
@@ -493,7 +493,7 @@ func (d DynamoDB) UpdateWorkflow(ctx context.Context, workflow models.Workflow) 
 			case dynamodb.ErrCodeConditionalCheckFailedException:
 				return store.NewNotFound(workflow.ID)
 			case "ValidationException":
-				if awsErr.Message() == errMessageItemTooLarge {
+				if awsErr.Message() == errMessageItemTooLarge && workflow.Jobs != nil {
 					log.WarnD("workflow-too-large", logger.M{
 						"error":     awsErr.Message(),
 						"id":        workflow.ID,


### PR DESCRIPTION
## Overview:
In Flare-1520 we saw one workflow retrying indefinitely because the size was too large even without the jobs
