### PR TITLE
add tags for state machines created by embedded wfm

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+)
+
+func ToTagMap(wdTags map[string]interface{}) map[string]string {
+	tags := map[string]string{}
+	for k, v := range wdTags {
+		vs, ok := v.(string)
+		if ok {
+			tags[k] = vs
+		}
+	}
+	return tags
+}
+
+func ToSFNTags(tags map[string]string) []*sfn.Tag {
+	sfnTags := []*sfn.Tag{}
+	for k, v := range tags {
+		sfnTags = append(sfnTags, &sfn.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return sfnTags
+}


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-5595

## Overview:
currently statemachines created by embedded wfm are not taged. Copy what we are doing for regular wfm and tag them!

This will help with attributing costs and also with creating precise datadog monitors

If you made any changes to swagger.yml:
- [na] Update swagger.yml version
- [na] Run "make generate"
