### PR TITLE
canceling something that has succeded is a bad request now, not a 5xx

### DIFF
--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -438,7 +438,9 @@ func (wm *SFNWorkflowManager) RetryWorkflow(ctx context.Context, ogWorkflow mode
 
 func (wm *SFNWorkflowManager) CancelWorkflow(ctx context.Context, workflow *models.Workflow, reason string) error {
 	if workflow.Status == models.WorkflowStatusSucceeded || workflow.Status == models.WorkflowStatusFailed {
-		return fmt.Errorf("Cancellation not allowed. Workflow %s is %s", workflow.ID, workflow.Status)
+		return models.BadRequest{
+			Message: fmt.Sprintf("Cancellation not allowed. Workflow %s is %s", workflow.ID, workflow.Status),
+		}
 	}
 
 	wd := workflow.WorkflowDefinition


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-5841

## Overview:
This cropped up when trying to batch cancel workflows and accidentally attempting to cancel succeeded workflows resulted in lots of 5xx errors, containers restarting, envoy ejections and pages. What should have happened is a simple 4xx. Now that happens. 


If you made any changes to swagger.yml:
- [ ] Update swagger.yml version 
- [x] Run "make generate"

## Testing
<img width="1439" alt="image" src="https://github.com/Clever/workflow-manager/assets/101210272/29cba54c-57cd-4d3e-a683-1326e75beaa0">

## Rollout
