### PR TITLE
Worfklow manager ops script: Fetch workflow history to force workflow update

### DIFF
--- a/scripts/workflows-ops/main.go
+++ b/scripts/workflows-ops/main.go
@@ -36,6 +36,8 @@ var (
 	limit          int64 = 50
 	oldestFirst          = true
 	resolvedByUser       = false
+	// We need to fetchHistory in the 'refresh' case in order to force an update
+	fetchHistory = true
 )
 
 // Progress metrics
@@ -152,7 +154,7 @@ func worker(ctx context.Context, cl *client.WagClient, flags cmdFlags, work <-ch
 				Reason:     &models.CancelReason{Reason: flags.cancelReason},
 			})
 		} else if flags.cmd == "refresh" {
-			r, err = cl.GetWorkflowByID(ctx, &models.GetWorkflowByIDInput{WorkflowID: id})
+			r, err = cl.GetWorkflowByID(ctx, &models.GetWorkflowByIDInput{WorkflowID: id, FetchHistory: &fetchHistory})
 		}
 
 		if err != nil {

--- a/scripts/workflows-ops/main.go
+++ b/scripts/workflows-ops/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	CheckForContinue()
 
-	os.Setenv("SERVICE_WORKFLOW_MANAGER_HTTP_HOST", "production--workflow-manager--a6127c9c.int.clever.com")
+	os.Setenv("SERVICE_WORKFLOW_MANAGER_HTTP_HOST", "production--workflow-manager--8e75288e.int.clever.com")
 	os.Setenv("SERVICE_WORKFLOW_MANAGER_HTTP_PORT", "443")
 	os.Setenv("SERVICE_WORKFLOW_MANAGER_HTTP_PROTO", "https")
 	cl, err := client.NewFromDiscovery(clientconfig.WithoutTracing("workflow-manager"))


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/INFRANG-6114

## Overview:
We need to fetch the workflow history in order to force a status update when running this script with the 'refresh' cmd.

If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing
Tested locally. Prior to the fetchHistory change the workflow status was not being updated. After the change, the status was updated.

## Rollout
