### PR TITLE
Bugfix: add application tag to new state machines correctly

### DIFF
--- a/executor/sfnconventions/sfnconventions.go
+++ b/executor/sfnconventions/sfnconventions.go
@@ -47,6 +47,7 @@ func StateMachineNameParts(stateMachineName string) (*SMParts, error) {
 // StateMachineTags returns the tags we place on state machine resources.
 func StateMachineTags(namespace, wdName string, wdVersion int64, startAt string, defaultTags map[string]string) map[string]string {
 	tags := map[string]string{
+		"application":                  wdName,
 		"environment":                  namespace,
 		"workflow-definition-name":     wdName,
 		"workflow-definition-version":  fmt.Sprintf("%d", wdVersion),

--- a/executor/workflow_manager_sfn.go
+++ b/executor/workflow_manager_sfn.go
@@ -281,13 +281,8 @@ func (wm *SFNWorkflowManager) describeOrCreateStateMachine(ctx context.Context, 
 	}
 	awsStateMachineDef := string(awsStateMachineDefBytes)
 
-	// we use the 'application' tag to attribute costs, so if it wasn't explicitly specified, set it to the workflow name
-	if _, ok := wd.DefaultTags["application"]; !ok {
-		wd.DefaultTags["application"] = wd.Name
-	}
 	log.InfoD("create-state-machine", logger.M{"definition": awsStateMachineDef, "name": awsStateMachineName})
-	var lc *sfn.LoggingConfiguration
-	lc = loggingConfiguration(sfnconventions.LogGroupArn(wm.region, wm.accountID, awsStateMachineName))
+	lc := loggingConfiguration(sfnconventions.LogGroupArn(wm.region, wm.accountID, awsStateMachineName))
 	// must create the log group before creating a state machine referencing the log group
 	if err := wm.createLogGroupsForLoggingConfiguration(ctx, tags, lc); err != nil {
 		return nil, err

--- a/scripts/backfill-application-tag/README.md
+++ b/scripts/backfill-application-tag/README.md
@@ -1,0 +1,5 @@
+# backfill-application-tag
+
+This is a script for adding the tag `application` to existing state machines that have a `workflow-definition-name` tag, copying the value over. It was written because (a) we like the `application` tag at Clever for cost attribution (used widely, not just with `workflow-manager`, and (b) a bug in workflow-manager caused this tag to not be applied.
+
+To run, use `go run .` in this directory. Requires AWS permissions. There are several constants at the top of that file that control its behavior, see comments in code.

--- a/scripts/backfill-application-tag/main.go
+++ b/scripts/backfill-application-tag/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sfn"
+)
+
+const (
+	sfnRegion = "us-west-2"
+
+	// If empty, tag all state machines
+	// If non-empty, before tagging a state machine, make sure its current env tag matches this value
+	environmentToTag = "clever-dev"
+
+	// If true, iterate through all state machines and check their tags but don't apply any tags
+	// if false, that plus actually tag them.
+	dryRun = true
+)
+
+func main() {
+
+	sfnsess, err := session.NewSession(aws.NewConfig().WithRegion(sfnRegion))
+	if err != nil {
+		log.Fatalf("new AWS session: %v", err)
+	}
+	sfnAPI := sfn.New(sfnsess)
+
+	ctx := context.Background()
+
+	stateMachineArns := []string{}
+
+	err = sfnAPI.ListStateMachinesPagesWithContext(ctx, &sfn.ListStateMachinesInput{}, func(out *sfn.ListStateMachinesOutput, lastPage bool) bool {
+		for _, machine := range out.StateMachines {
+			stateMachineArns = append(stateMachineArns, *machine.StateMachineArn)
+		}
+		return true
+	})
+
+	// limit ourselves to one state machine every 300ms or less
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for _, machineArn := range stateMachineArns {
+		if environmentToTag != "" {
+			arnParts := strings.Split(machineArn, ":")
+			machineName := arnParts[len(arnParts)-1]
+
+			// all workflow-manager state machines are named <env>--<other stuff>
+			dashParts := strings.Split(machineName, "--")
+			if dashParts[0] != environmentToTag {
+				continue
+			}
+		}
+
+		<-ticker.C
+		tagOutput, err := retryThrottles(func() (*sfn.ListTagsForResourceOutput, error) {
+			return sfnAPI.ListTagsForResource(&sfn.ListTagsForResourceInput{
+				ResourceArn: &machineArn,
+			})
+		}, 5*time.Second)
+
+		if err != nil {
+			fmt.Printf("got error listing tags for %s: %v\n", machineArn, err)
+		}
+
+		tagMap := map[string]string{}
+		for _, tag := range tagOutput.Tags {
+			tagMap[*tag.Key] = *tag.Value
+		}
+		if _, found := tagMap["application"]; found {
+			continue
+		}
+		if environmentToTag != "" && tagMap["environment"] != environmentToTag {
+			continue
+		}
+		if workflowName, found := tagMap["workflow-definition-name"]; found {
+			if dryRun {
+				fmt.Printf("would tag %s\n", machineArn)
+				continue
+			} else {
+				fmt.Printf("tagging %s\n", machineArn)
+			}
+
+			_, err := retryThrottles(func() (struct{}, error) {
+				_, err := sfnAPI.TagResource(&sfn.TagResourceInput{
+					ResourceArn: &machineArn,
+					Tags: []*sfn.Tag{
+						{Key: aws.String("application"), Value: &workflowName},
+					},
+				})
+				return struct{}{}, err
+			}, 5*time.Second)
+
+			if err != nil {
+				log.Fatalf("error adding tags for %s: %v\n", machineArn, err)
+
+			}
+		}
+	}
+
+	if err != nil {
+		log.Fatalf("iterating over state machines: %v", err)
+	}
+}
+
+func retryThrottles[T any](f func() (T, error), waitTime time.Duration) (T, error) {
+	t, err := f()
+	if aerr, ok := err.(awserr.Error); ok && request.IsErrorThrottle(aerr) {
+		log.Printf("sleeping...\n")
+		time.Sleep(waitTime)
+		return retryThrottles(f, waitTime)
+
+	}
+	return t, err
+}


### PR DESCRIPTION
## Link to JIRA:
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-5585)

## Overview:
This was broken in a previous refactor related to tags when trying to get the same tags applied to the log group.

## Testing

Created https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/statemachines/view/arn%3Aaws%3Astates%3Aus-west-2%3A589690932525%3AstateMachine%3Aclever-dev--sfncli-test-master--0--echo from local.

For the script, I ran it locally exactly as shown in this PR. It took 38 minutes (for clever-dev, dry run). It took 38 minutes, occasionally printing `sleeping...` so the value for the ticker i chose is in the right ballpark (no sleeps would have meant I could go faster).

## Rollout

(a) Merge
(b) Run the script on `clever-dev` and `production`. (Note this doesn't affect embedded workflow manager, those are already tagged properly).