### PR TITLE
Enhancements to workflow-ops scripts

### DIFF
--- a/scripts/workflows-ops/README.md
+++ b/scripts/workflows-ops/README.md
@@ -9,6 +9,7 @@ The script accepts the following command-line arguments:
 - `workflow`: The name of the workflow, for example `multiverse:master`.
 - `cmd`: The command to execute. Can be set to `cancel` or `refresh`.
 - `status`: The status of the workflow to filter by, for example `queued` or `running`.
+- `rate-limit`: A cap on the number of the workflows to enqueue for refresh per second.
 
 Example usage:
 
@@ -18,4 +19,11 @@ go run main.go -workflow multiverse:master -status running -cmd refresh
 
 ## Notes
 
-You should be careful when running this script since the impact of running this script with wrong inputs is quite high! Consider asking for another set of eyes when you run this script.
+- You should be careful when running this script since the impact of running this script with wrong inputs is quite high! Consider asking for another set of eyes when you run this script.
+- If you use the default `rate-limit`, you may experience some DynamoDB throttling, especially at the beginning before the table scales up. You can start off with a value of 10 or so, and ramp up to
+  potentially as much as 100 or 125 as the table scales up. Note the DDB capacity also depends on the workflow - more DDB capacity will be used for large workflows with many steps.
+- If you want to refresh _all_ workflows, you can do the following:
+  - Change to `ark-config`, do a `git pull`, then run Run `ls -1 | rev | cut -c 5- | rev > workflows.txt`.
+  - Move that `workflows.txt` file here.
+  - Adjust the rate limit if desired in `./run-all.sh`
+  - Do `./run-all.sh`

--- a/scripts/workflows-ops/run-all.sh
+++ b/scripts/workflows-ops/run-all.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+while read -r w; do
+    echo y | go run main.go -workflow "${w}:master" -status running -cmd refresh -rate-limit 100
+    echo y | go run main.go -workflow "${w}:master" -status queued -cmd refresh -rate-limit 100
+done < workflows.txt


### PR DESCRIPTION
## Link to JIRA:
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-6265)

## Overview:
1. Allow setting the rate limit through command line flag and increase the default. I can get up to 100ish (more for short e.g. one-state workflows) on my laptop. But at that scale it will create DB throttling unless the DB is warmed up, so starting with 38 in the default.

2. Wait-ish for workers to be done before exiting.

If you made any changes to swagger.yml: N/A

## Testing

I ran this stuff for FLARE-1667

## Rollout
